### PR TITLE
Incorporating a feedback from KostyaSha and downgraded core to 1.545

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.580.1</version>
+    <version>1.545</version>
     <relativePath/>
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/DockerRegistryEndpoint.java
@@ -2,9 +2,12 @@ package org.jenkinsci.plugins.docker.commons;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.HostnameRequirement;
+import com.google.common.base.Charsets;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractBuild;
@@ -13,11 +16,14 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.remoting.VirtualChannel;
+import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import org.apache.commons.codec.binary.Base64;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.URL;
@@ -25,12 +31,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.*;
-import com.cloudbees.plugins.credentials.common.StandardCredentials;
-import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
-import hudson.util.ListBoxModel;
-import javax.annotation.Nonnull;
-import org.apache.commons.io.Charsets;
-import org.kohsuke.stapler.AncestorInPath;
 
 /**
  * Encapsulates the endpoint of DockerHub and how to interact with it.

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/DockerRegistryToken.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/DockerRegistryToken.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.docker.commons;
 
+import hudson.remoting.Callable;
 import hudson.remoting.VirtualChannel;
-import jenkins.security.MasterToSlaveCallable;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.FileUtils;
 
@@ -42,7 +42,7 @@ public final class DockerRegistryToken implements Serializable {
      * This is done by inserting the token into {@code ~/.dockercfg}
      */
     public KeyMaterial materialize(final URL endpoint, VirtualChannel target) throws InterruptedException, IOException {
-        target.call(new MasterToSlaveCallable<Void, IOException>() {
+        target.call(new Callable<Void, IOException>() {
             /**
              * Insert the token into {@code ~/.dockercfg}
              */


### PR DESCRIPTION
See
https://github.com/jenkinsci/docker-commons-plugin/commit/2e03b78e1c3ec3407b0869e7dfa4416dd77b7d02#commitcomment-10646991

I don't think 1.580 is "latest core", but I have no objections to rely
on 1.545 if he needs it, hence the change.

This version of the core apparently relied on older apache commons-io,
so Charset.UTF8 had to be taken from somewhere else.