### PR TITLE
[WiP] Simplified DockerClient

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/client/DockerClient.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2013-2015, CloudBees, Inc.
+ * Copyright (c) 2015, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -209,10 +209,10 @@ public class DockerClient {
      */
     public String whoAmI() throws IOException, InterruptedException {
         ByteArrayOutputStream userId = new ByteArrayOutputStream();
-        launcher.launch().cmds("id", "-u").stdout(userId).quiet(true).join();
+        launcher.launch().cmds("id", "-u").stdout(userId).join();
 
         ByteArrayOutputStream groupId = new ByteArrayOutputStream();
-        launcher.launch().cmds("id", "-g").stdout(groupId).quiet(true).join();
+        launcher.launch().cmds("id", "-g").stdout(groupId).join();
 
         return String.format("%s:%s", userId.toString().trim(), groupId.toString().trim());
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/client/DockerClient.java
@@ -93,13 +93,7 @@ public class DockerClient {
         LaunchResult result = launch(null, args);
         if (result.getStatus() == 0) {
             String containerId = result.getOut().trim();
-            String host = inspect(containerId, ".Config.Hostname");
-            String containerName = inspect(containerId, ".Name");
-            Date created = getCreatedDate(containerId);
-
-            // TODO get tags and add for ContainerRecord
-            return new ContainerRecord(host, containerId, containerName, created.getTime(), Collections.<String,String>emptyMap());
-
+            return getContainerRecord(containerId);
         } else {
             throw new IOException(String.format("Failed to run image '%s'.", image));
         }
@@ -141,7 +135,6 @@ public class DockerClient {
     private LaunchResult launch(FilePath pwd, @Nonnull String... args) throws IOException, InterruptedException {
         return launch(pwd, new ArgumentListBuilder(args));
     }
-
     private LaunchResult launch(FilePath pwd, @Nonnull ArgumentListBuilder args) throws IOException, InterruptedException {
         EnvVars envVars = new EnvVars();
 
@@ -190,5 +183,14 @@ public class DockerClient {
 
         return String.format("%s:%s", userId.toString().trim(), groupId.toString().trim());
 
+    }
+
+    private ContainerRecord getContainerRecord(String containerId) throws IOException, InterruptedException {
+        String host = inspect(containerId, ".Config.Hostname");
+        String containerName = inspect(containerId, ".Name");
+        Date created = getCreatedDate(containerId);
+
+        // TODO get tags and add for ContainerRecord
+        return new ContainerRecord(host, containerId, containerName, created.getTime(), Collections.<String,String>emptyMap());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/client/DockerClient.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/client/DockerClient.java
@@ -1,0 +1,194 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.commons.client;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.util.ArgumentListBuilder;
+import org.jenkinsci.plugins.docker.commons.KeyMaterial;
+import org.jenkinsci.plugins.docker.commons.fingerprint.ContainerRecord;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class DockerClient {
+
+    private static final Logger LOGGER = Logger.getLogger(DockerClient.class.getName());
+
+    // e.g. 2015-04-09T13:40:21.981801679Z
+    public static final String DOCKER_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+
+    private Launcher launcher;
+    private KeyMaterial keyMaterial;
+
+    public DockerClient(@Nonnull Launcher launcher) {
+        this.launcher = launcher;
+    }
+
+    public DockerClient setKeyMaterial(@Nonnull KeyMaterial keyMaterial) {
+        this.keyMaterial = keyMaterial;
+        return this;
+    }
+
+    // TODO return a fingerprint
+    public void build(@Nonnull FilePath workspace, @CheckForNull String tag) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder();
+        args.add("docker", "build");
+        if (tag != null) {
+            args.add("-t", tag);
+        }
+        args.add(".");
+        LaunchResult result = launch(workspace, args);
+        if (result.getStatus() != 0) {
+            throw new IOException(String.format("Failed to build Dockerfile in '%s'.", workspace));
+        }
+    }
+
+    public ContainerRecord run(@Nonnull String image, @Nonnull String workdir, @Nonnull Map<String, String> volumes, @Nonnull String user, @CheckForNull String ... command) throws IOException, InterruptedException {
+        ArgumentListBuilder args = new ArgumentListBuilder();
+
+        args.add("docker", "run", "-t", "-d", "-u", user, "-w", workdir);
+        for (Map.Entry<String, String> volume : volumes.entrySet()) {
+            args.add("-v", volume.getKey() + ":" + volume.getValue() + ":rw");
+        }
+        if (command != null) {
+            args.add(image).add(command);
+        }
+
+        // TODO: change to use BourneShellScript to make it durable
+        LaunchResult result = launch(null, args);
+        if (result.getStatus() == 0) {
+            String containerId = result.getOut().trim();
+            String host = inspect(containerId, ".Config.Hostname");
+            String containerName = inspect(containerId, ".Name");
+            Date created = getCreatedDate(containerId);
+
+            // TODO get tags and add for ContainerRecord
+            return new ContainerRecord(host, containerId, containerName, created.getTime(), Collections.<String,String>emptyMap());
+
+        } else {
+            throw new IOException(String.format("Failed to run image '%s'.", image));
+        }
+    }
+
+    public void kill(@Nonnull String containerId) throws IOException, InterruptedException {
+        LaunchResult result = launch("docker", "kill", containerId);
+        if (result.getStatus() != 0) {
+            throw new IOException(String.format("Failed to kill container '%s'.", containerId));
+        }
+        result = launch("docker", "rm", containerId);
+        if (result.getStatus() != 0) {
+            throw new IOException(String.format("Failed to rm container '%s'.", containerId));
+        }
+    }
+
+    private String inspect(@Nonnull String objectId, @Nonnull String fieldPath) throws IOException, InterruptedException {
+        LaunchResult result = launch("docker", "inspect", "-f", String.format("{{%s}}", fieldPath), objectId);
+        if (result.getStatus() == 0) {
+            return result.getOut();
+        } else {
+            return null;
+        }
+    }
+
+    private Date getCreatedDate(@Nonnull String objectId) throws IOException, InterruptedException {
+        String createdString = inspect(objectId, ".Created");
+        try {
+            // TODO Currently truncating. Find out how to specify last part for parsing (TZ etc)
+            return new SimpleDateFormat(DOCKER_DATE_TIME_FORMAT).parse(createdString.substring(0, DOCKER_DATE_TIME_FORMAT.length() - 2));
+        } catch (ParseException e) {
+            throw new IOException(String.format("Error parsing created date '' for object ''.", createdString, objectId), e);
+        }
+    }
+
+    private LaunchResult launch(@Nonnull String... args) throws IOException, InterruptedException {
+        return launch(null, args);
+    }
+    private LaunchResult launch(FilePath pwd, @Nonnull String... args) throws IOException, InterruptedException {
+        return launch(pwd, new ArgumentListBuilder(args));
+    }
+
+    private LaunchResult launch(FilePath pwd, @Nonnull ArgumentListBuilder args) throws IOException, InterruptedException {
+        EnvVars envVars = new EnvVars();
+
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.log(Level.FINE, "Executing docker command {0}", args.toString());
+        }
+
+        if (keyMaterial != null) {
+            envVars.putAll(keyMaterial.env());
+        }
+
+        Launcher.ProcStarter procStarter = launcher.launch();
+
+        if (pwd != null) {
+            procStarter.pwd(pwd);
+        }
+
+        LaunchResult result = new LaunchResult();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        try {
+            result.setStatus(procStarter.cmds(args).envs(envVars).stdout(out).stderr(err).join());
+            return result;
+        } finally {
+            try {
+                result.setOut(out.toString());
+                out.close();
+            } finally {
+                result.setErr(err.toString());
+                err.close();
+            }
+        }
+    }
+
+    /**
+     * Who is executing this {@link DockerClient} instance.
+     *
+     * @return a {@link String} containing the <strong>uid:gid</strong>.
+     */
+    public String whoAmI() throws IOException, InterruptedException {
+        ByteArrayOutputStream userId = new ByteArrayOutputStream();
+        launcher.launch().cmds("id", "-u").stdout(userId).quiet(true).join();
+
+        ByteArrayOutputStream groupId = new ByteArrayOutputStream();
+        launcher.launch().cmds("id", "-g").stdout(groupId).quiet(true).join();
+
+        return String.format("%s:%s", userId.toString().trim(), groupId.toString().trim());
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/client/LaunchResult.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/client/LaunchResult.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.commons.client;
+
+/**
+ * Launch result.
+ *
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class LaunchResult {
+
+    private int status;
+    private String out;
+    private String err;
+
+    public int getStatus() {
+        return status;
+    }
+
+    public LaunchResult setStatus(int status) {
+        this.status = status;
+        return this;
+    }
+
+    public String getOut() {
+        return out;
+    }
+
+    public LaunchResult setOut(String out) {
+        this.out = out;
+        return this;
+    }
+
+    public String getErr() {
+        return err;
+    }
+
+    public LaunchResult setErr(String err) {
+        this.err = err;
+        return this;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/client/LaunchResult.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/client/LaunchResult.java
@@ -48,7 +48,9 @@ public class LaunchResult {
     }
 
     public LaunchResult setOut(String out) {
-        this.out = out;
+        if (out != null) {
+            this.out = out.trim();
+        }
         return this;
     }
 
@@ -57,7 +59,9 @@ public class LaunchResult {
     }
 
     public LaunchResult setErr(String err) {
-        this.err = err;
+        if (err != null) {
+            this.err = err.trim();
+        }
         return this;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
@@ -30,12 +30,14 @@ import hudson.model.TaskListener;
 import org.jenkinsci.plugins.docker.commons.fingerprint.ContainerRecord;
 import org.jenkinsci.plugins.docker.commons.impl.ServerKeyMaterialImpl;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Collections;
 
 /**
@@ -58,14 +60,29 @@ public class DockerClientTest {
         //  -DDOCKER_COMMAND=/usr/local/bin/docker
         //  -DDOCKER_HOST_FOR_TEST="tcp://192.168.59.103:2376"
         //  -DDOCKER_HOST_KEY_DIR_FOR_TEST="/Users/tfennelly/.boot2docker/certs/boot2docker-vm"
-        ServerKeyMaterialImpl keyMaterial = new ServerKeyMaterialImpl(System.getProperty("DOCKER_HOST_FOR_TEST"),
-                new FilePath(new File(System.getProperty("DOCKER_HOST_KEY_DIR_FOR_TEST"))));
+        String docker_host_for_test = System.getProperty("DOCKER_HOST_FOR_TEST");
+        String docker_host_key_dir_for_test = System.getProperty("DOCKER_HOST_KEY_DIR_FOR_TEST");
+        if (docker_host_for_test != null && docker_host_key_dir_for_test != null) {
+            ServerKeyMaterialImpl keyMaterial = new ServerKeyMaterialImpl(docker_host_for_test,
+                    new FilePath(new File(docker_host_key_dir_for_test)));
 
-        dockerClient = new DockerClient(launcher).setKeyMaterial(keyMaterial);
+            dockerClient = new DockerClient(launcher).setKeyMaterial(keyMaterial);
+        }
+    }
+
+    @Test
+    public void test_build() throws IOException, InterruptedException {
+        Assume.assumeNotNull(dockerClient);
+
+        FilePath pwd = getParentPath("/dockerfile1/Dockerfile");
+        String imageId = dockerClient.build(pwd, null);
+        Assert.assertEquals(64, imageId.length());
     }
 
     @Test
     public void test_run() throws IOException, InterruptedException {
+        Assume.assumeNotNull(dockerClient);
+
         ContainerRecord containerRecord =
                 dockerClient.run("learn/tutorial", null, Collections.<String, String>emptyMap(),
                 dockerClient.whoAmI(), "echo", "hello world");
@@ -79,5 +96,15 @@ public class DockerClientTest {
         Assert.assertNotNull(dockerClient.inspect(containerRecord.getContainerId(), ".Name"));
         dockerClient.kill(containerRecord.getContainerId());
         Assert.assertNull(dockerClient.inspect(containerRecord.getContainerId(), ".Name"));
+    }
+
+    private FilePath getParentPath(String classpathRes) {
+        URL resUrl = getClass().getResource(classpathRes);
+
+        if (resUrl == null) {
+            Assert.fail("Cannot find resource " + classpathRes + " on classpath.");
+        }
+
+        return new FilePath(new File(new File(resUrl.getPath()).getParent()));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright (c) 2013-2015, CloudBees, Inc.
+ * Copyright (c) 2015, CloudBees, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013-2015, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.docker.commons.client;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.StreamBuildListener;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.docker.commons.impl.ServerKeyMaterialImpl;
+import org.junit.Before;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+/**
+ * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
+ */
+public class DockerClientTest {
+
+    protected Launcher.LocalLauncher launcher;
+    protected ServerKeyMaterialImpl keyMaterial;
+
+    @Before
+    public void setup() {
+
+        // Set stuff up for the test
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        TaskListener taskListener = new StreamBuildListener(outputStream);
+        launcher = new Launcher.LocalLauncher(taskListener);
+
+        // Create the KeyMaterial for connecting to the docker daemon
+        // TODO a better way of setting this for the test, if there is on
+        keyMaterial = new ServerKeyMaterialImpl("tcp://192.168.59.103:2376",
+                new FilePath(new File("/Users/tfennelly/.boot2docker/certs/boot2docker-vm")));
+
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
@@ -41,9 +41,11 @@ public class DockerClientTest {
     protected Launcher.LocalLauncher launcher;
     protected ServerKeyMaterialImpl keyMaterial;
 
+
+
+
     @Before
     public void setup() {
-
         // Set stuff up for the test
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         TaskListener taskListener = new StreamBuildListener(outputStream);

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/client/DockerClientTest.java
@@ -27,34 +27,57 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.StreamBuildListener;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.docker.commons.fingerprint.ContainerRecord;
 import org.jenkinsci.plugins.docker.commons.impl.ServerKeyMaterialImpl;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public class DockerClientTest {
 
-    protected Launcher.LocalLauncher launcher;
-    protected ServerKeyMaterialImpl keyMaterial;
-
-
-
+    private DockerClient dockerClient;
 
     @Before
     public void setup() {
         // Set stuff up for the test
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         TaskListener taskListener = new StreamBuildListener(outputStream);
-        launcher = new Launcher.LocalLauncher(taskListener);
+        Launcher.LocalLauncher launcher = new Launcher.LocalLauncher(taskListener);
 
         // Create the KeyMaterial for connecting to the docker daemon
-        // TODO a better way of setting this for the test, if there is on
-        keyMaterial = new ServerKeyMaterialImpl("tcp://192.168.59.103:2376",
-                new FilePath(new File("/Users/tfennelly/.boot2docker/certs/boot2docker-vm")));
+        // TODO a better way of setting the env for the test
+        // E.g. currently need to add the following to you env
+        //  -DDOCKER_COMMAND=/usr/local/bin/docker
+        //  -DDOCKER_HOST_FOR_TEST="tcp://192.168.59.103:2376"
+        //  -DDOCKER_HOST_KEY_DIR_FOR_TEST="/Users/tfennelly/.boot2docker/certs/boot2docker-vm"
+        ServerKeyMaterialImpl keyMaterial = new ServerKeyMaterialImpl(System.getProperty("DOCKER_HOST_FOR_TEST"),
+                new FilePath(new File(System.getProperty("DOCKER_HOST_KEY_DIR_FOR_TEST"))));
 
+        dockerClient = new DockerClient(launcher).setKeyMaterial(keyMaterial);
+    }
+
+    @Test
+    public void test_run() throws IOException, InterruptedException {
+        ContainerRecord containerRecord =
+                dockerClient.run("learn/tutorial", null, Collections.<String, String>emptyMap(),
+                dockerClient.whoAmI(), "echo", "hello world");
+
+        Assert.assertEquals(64, containerRecord.getContainerId().length());
+        Assert.assertTrue(containerRecord.getContainerName().length() > 0);
+        Assert.assertTrue(containerRecord.getHost().length() > 0);
+        Assert.assertTrue(containerRecord.getCreated() > 1000000000000L);
+
+        // Also test that the kill works and cleans up after itself
+        Assert.assertNotNull(dockerClient.inspect(containerRecord.getContainerId(), ".Name"));
+        dockerClient.kill(containerRecord.getContainerId());
+        Assert.assertNull(dockerClient.inspect(containerRecord.getContainerId(), ".Name"));
     }
 }

--- a/src/test/resources/dockerfile1/Dockerfile
+++ b/src/test/resources/dockerfile1/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu
+
+MAINTAINER Tom Fennelly <tom.fennelly@gmail.com>


### PR DESCRIPTION
Simplified replacement for https://github.com/jenkinsci/docker-commons-plugin/pull/3

TODO:

- [x] Add test
- [x] Return `build` image ID that can be used for fingerprinting.
- [ ] Change `run` to first do a `docker pull` using `BourneShellScript` (durable)