### PR TITLE
Add equals() and hashcode() methods to endpoint classes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/DockerRegistryEndpoint.java
@@ -159,6 +159,32 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
         return "DockerRegistryEndpoint[" + url + ";credentialsId=" + credentialsId + "]";
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 31 * hash + (this.url != null ? this.url.hashCode() : 0);
+        hash = 31 * hash + (this.credentialsId != null ? this.credentialsId.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final DockerRegistryEndpoint other = (DockerRegistryEndpoint) obj;
+        if ((this.url == null) ? (other.url != null) : !this.url.equals(other.url)) {
+            return false;
+        }
+        if ((this.credentialsId == null) ? (other.credentialsId != null) : !this.credentialsId.equals(other.credentialsId)) {
+            return false;
+        }
+        return true;
+    }
+    
     @Extension
     public static class DescriptorImpl extends Descriptor<DockerRegistryEndpoint> {
         @Override

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/DockerServerEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/DockerServerEndpoint.java
@@ -111,6 +111,32 @@ public class DockerServerEndpoint extends AbstractDescribableImpl<DockerServerEn
         return "DockerServerEndpoint[" + uri + ";credentialsId=" + credentialsId + "]";
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 13 * hash + (this.uri != null ? this.uri.hashCode() : 0);
+        hash = 13 * hash + (this.credentialsId != null ? this.credentialsId.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final DockerServerEndpoint other = (DockerServerEndpoint) obj;
+        if ((this.uri == null) ? (other.uri != null) : !this.uri.equals(other.uri)) {
+            return false;
+        }
+        if ((this.credentialsId == null) ? (other.credentialsId != null) : !this.credentialsId.equals(other.credentialsId)) {
+            return false;
+        }
+        return true;
+    }
+    
     @Extension
     public static class DescriptorImpl extends Descriptor<DockerServerEndpoint> {
         @Override


### PR DESCRIPTION
Methods are required to use EndPoints as a key in hash maps

@stephenc @reviewbybees