### PR TITLE
Javadoc refinement relating to base images

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerAncestorFingerprintFacet.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerAncestorFingerprintFacet.java
@@ -29,7 +29,8 @@ public class DockerAncestorFingerprintFacet extends DockerRunPtrFingerprintFacet
      * In principle there could be several, in case distinct {@code Dockerfile}s used distinct {@code FROM} images,
      * yet wound up producing the same result (because some corresponded to intermediate layers which were cached).
      * This is unlikely but possible.
-     * @return a set of 64-digit IDs, never empty, typically a singleton
+     * The set may be empty in case you built a base image ({@code FROM scratch}), in which case there is no ID for the ancestor.
+     * @return a set of 64-digit IDs, typically a singleton
      */
     public synchronized @Nonnull Set<String> getAncestorImageIds() {
         return new TreeSet<String>(ancestorImageIds);


### PR DESCRIPTION
https://github.com/jglick/docker-commons-plugin/commit/91fdceac63148f267141bf681a2b8726770df6d0 in #21 led to the situation that the ancestor ID set is actually empty.

It would have been nice if Docker assigned the ID `0000000000000000000000000000000000000000000000000000000000000000` (or anything, really) to the empty image. But it does not seem to have a concept of zero:

```
$ docker inspect -f {{.Parent}} ubuntu

$ docker inspect scratch
Error: No such image or container: scratch
[]
```

The choices here are:

* Use `null` as the parameter to `addFromFacet`, as I have done, but do not add it to `DockerAncestorFingerprintFacet.ancestorImageIds`.
* Do not even create the `DockerAncestorFingerprintFacet` (but if it already exists, leave its `ancestorImageIds` unmodified).
* Add a `null` to the set, and make callers check for null.
* Use the empty string, and make callers check `.isEmpty()` before assuming an “ID” is really a 64-digit hash.
* Adopt the convention of a zero-padded hash for `scratch`, knowing that `docker-inspect` will not produce it.
* Not support fingerprinting of base images at all.

None seem attractive, but @reviewbybees