### PR TITLE
Prevent IllegalStateException when reusing the NullKeyMaterialFactory

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/NullKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/NullKeyMaterialFactory.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.docker.commons.impl;
 
 import org.jenkinsci.plugins.docker.commons.KeyMaterial;
+import org.jenkinsci.plugins.docker.commons.KeyMaterialContext;
 import org.jenkinsci.plugins.docker.commons.KeyMaterialFactory;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -21,5 +22,10 @@ public final class NullKeyMaterialFactory extends KeyMaterialFactory {
     @Override
     public KeyMaterial materialize() throws IOException, InterruptedException {
         return KeyMaterial.NULL;
+    }
+
+    @Override
+    public synchronized KeyMaterialFactory contextualize(KeyMaterialContext context) {
+        return this;
     }
 }


### PR DESCRIPTION
If two calls are made to contextualize from two different places with empty credentials, ie. DockerServerEndpoint and DockerRegistryEndpoint, they both reuse the same object and the second call gets IllegalStateException

@reviewbybees