### PR TITLE
Integrate docker-java dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
       <version>1.22</version>
     </dependency>
     <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java</artifactId>
+      <version>1.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authentication-tokens</artifactId>
       <version>1.1</version>


### PR DESCRIPTION
It's a follow-up to the discussion in https://github.com/jenkinsci/docker-build-publish-plugin/pull/22/files#r31504279.
We use docker-java in several docker plugins, so it makes sense to streamline the dependency via api plugin like docker-commons.

@reviewbybees