### PR TITLE
option to configure a default dockerhost value

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/global.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2015 Jesse Glick.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry field="defaultHost" title="Default Docker host URL">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/help-defaultHost.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/help-defaultHost.html
@@ -1,0 +1,5 @@
+<div>
+    URI to the Docker daemon to be used when none explicit is set
+    (typically <code>unix:///var/run/docker.sock</code>).
+    If left blank, <code>DOCKER_HOST</code> environment variable will be used
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/help-uri.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/help-uri.html
@@ -1,5 +1,6 @@
 <div>
     URI to the Docker server you are using.
     May be left blank to use the Docker default
-    (typically <code>unix:///var/run/docker.sock</code>).
+    (typically <code>unix:///var/run/docker.sock</code>)
+    as configured on global configuration.
 </div>


### PR DESCRIPTION
customizing dockerhost is an advanced usage for complex deployment workflows, and I guess most users will just rely on the same dockerhost for all jobs (especially considering docker-swarm usage).
BUT in some setup docker local socket is not set as /var/run/docker.sock

This PR allows administrator to configure a default dockerhost URL to be used when not overiden explicitly on job.
