### PR TITLE
prefer « Docker Host » terminology

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
@@ -96,7 +96,7 @@ public class DockerServerCredentials extends BaseStandardCredentials {
     public static class DescriptorImpl extends BaseStandardCredentialsDescriptor {
         @Override
         public String getDisplayName() {
-            return "Docker Server Certificate Authentication";
+            return "Docker Host Certificate Authentication";
         }
 
     }

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/config.jelly
@@ -25,7 +25,7 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-    <f:entry field="uri" title="Docker server URI">
+    <f:entry field="uri" title="Docker Host URI">
         <f:textbox/>
     </f:entry>
     <f:entry field="credentialsId" title="Server credentials">

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/help-uri.html
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint/help-uri.html
@@ -1,5 +1,5 @@
 <div>
-    URI to the Docker server you are using.
-    May be left blank to use the Docker default
-    (typically <code>unix:///var/run/docker.sock</code>).
+    URI to the Docker Host you are using.
+    May be left blank to use the Docker default (defined by DOCKER_HOST environment variable)
+    (typically <code>unix:///var/run/docker.sock</code> or <code>tcp://127.0.0.1:2375</code>).
 </div>


### PR DESCRIPTION
as this is what is used by Docker as well as env variable used by docker user to point to a docker daemon 
and we called « DockerServerEndpoint » in our own vocable