### PR TITLE
[FIXED-JENKINS-29627] - Fix issue with new docker version

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
@@ -86,24 +86,21 @@ public final class DockerRegistryToken implements Serializable {
                         json = JSONObject.fromObject(FileUtils.readFileToString(config, "UTF-8"));
                         auths = json.getJSONObject("auths");
                     } else {
-                        File dockercfg = new File(System.getProperty("user.home"), ".dockercfg");
-                        if (dockercfg.exists()) {
-                            config = dockercfg;
-                            auths = json = JSONObject.fromObject(FileUtils.readFileToString(dockercfg, "UTF-8"));
+                        config = new File(System.getProperty("user.home"), ".dockercfg");
+                        if (config.exists()) {
+                            auths = json = JSONObject.fromObject(FileUtils.readFileToString(config, "UTF-8"));
                         } else {
                             // Use legacy .dockercfg to ensure this works well with pre-1.7 docker client
                             // client will pick this one if .docker/config.json does not yet exists
                             auths = json = new JSONObject();
                         }
                     }
-
                     auths.put(endpoint.toString(), new JSONObject()
                             .accumulate("auth", getToken())
                             .accumulate("email", getEmail()));
-
+                    
                     FileUtils.writeStringToFile(config, json.toString(2), "UTF-8");
                 }
-
                 return null;
             }
         });


### PR DESCRIPTION
Hi,

I found a bug in the source code, when you install the plugin and docker 1.7.0 for the first time, it will create a config.json file which is fine for the new version but the Json format will use the old version which doesn't work with the 1.7.0


So by default for backward compatibilty, I create the old version in the old file and docker event the new version will be able to use it.