### PR TITLE
Fixing squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
@@ -45,6 +45,7 @@ import java.net.URL;
  * @see AuthenticationTokens
  */
 public final class DockerRegistryToken implements Serializable {
+    private static final long serialVersionUID = 1L;
     private final String email;
     private final String token;
 
@@ -109,5 +110,4 @@ public final class DockerRegistryToken implements Serializable {
         return KeyMaterialFactory.NULL;
     }
 
-    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/KeyMaterial.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/KeyMaterial.java
@@ -47,6 +47,11 @@ public abstract class KeyMaterial implements Closeable, Serializable {
      * Standardize serialization
      */
     private static final long serialVersionUID = 1L;
+    
+    /**
+     * {@link KeyMaterial} that does nothing.
+     */
+    public static final KeyMaterial NULL = new NullKeyMaterial();
 
     /**
      * The environment variables
@@ -71,11 +76,6 @@ public abstract class KeyMaterial implements Closeable, Serializable {
      */
     public abstract void close() throws IOException;
     
-    /**
-     * {@link KeyMaterial} that does nothing.
-     */
-    public static final KeyMaterial NULL = new NullKeyMaterial();
-
     private static final class NullKeyMaterial extends KeyMaterial implements Serializable {
         private static final long serialVersionUID = 1L;
         protected NullKeyMaterial() {

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/KeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/KeyMaterialFactory.java
@@ -52,6 +52,8 @@ public abstract class KeyMaterialFactory implements Serializable {
      */
     private static final long serialVersionUID = 1L;
     
+    public static final KeyMaterialFactory NULL = new NullKeyMaterialFactory();
+    
     private /* write once */ KeyMaterialContext context;
     
     protected synchronized void checkContextualized() {
@@ -105,5 +107,4 @@ public abstract class KeyMaterialFactory implements Serializable {
         return new CompositeKeyMaterialFactory(tmp.toArray(new KeyMaterialFactory[tmp.size()]));
     }
 
-    public static final KeyMaterialFactory NULL = new NullKeyMaterialFactory();
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
@@ -53,6 +53,8 @@ public class ServerKeyMaterialFactory extends KeyMaterialFactory {
     private final String cert;
     @CheckForNull 
     private final String ca;
+    
+    private static final long serialVersionUID = 1L;
 
     public ServerKeyMaterialFactory(@CheckForNull final DockerServerCredentials credentials) {
         if (credentials != null) {
@@ -101,8 +103,6 @@ public class ServerKeyMaterialFactory extends KeyMaterialFactory {
         dir.child(fileName).write(content,"UTF-8");
     }
 
-    private static final long serialVersionUID = 1L;
-    
     private static final class ServerKeyMaterial extends KeyMaterial {
 
         private final FilePath[] tempDirs;

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerRunFingerprintFacetTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerRunFingerprintFacetTest.java
@@ -38,6 +38,8 @@ import java.util.Collections;
  */
 public class DockerRunFingerprintFacetTest {
        
+    private static String IMAGE_ID = "0409d3ebf4f571d7dd2cf4b00f9d897f8af1d6d8a0f1ff791d173ba9891fd72f";
+    
     @Rule
     public JenkinsRule rule = new JenkinsRule();
     
@@ -65,5 +67,4 @@ public class DockerRunFingerprintFacetTest {
                 fpAction.getImageIDs().contains(IMAGE_ID));
     }
 
-    private static String IMAGE_ID = "0409d3ebf4f571d7dd2cf4b00f9d897f8af1d6d8a0f1ff791d173ba9891fd72f";    
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1213 -  The members of an interface declaration or class should appear in a pre-defined order". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1213


Please let me know if you have any questions.
Sameer Misger