### PR TITLE
Fixing squid:S1192 -   String literals should not be duplicated

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
@@ -48,6 +48,7 @@ public final class DockerRegistryToken implements Serializable {
     private final String email;
     private final String token;
 
+    private static final String charecterSet = "UTF-8";
     public DockerRegistryToken(String email, String token) {
         this.email = email;
         this.token = token;
@@ -83,12 +84,12 @@ public final class DockerRegistryToken implements Serializable {
 
                     File config = new File(System.getProperty("user.home"), ".docker/config.json");
                     if (config.exists()) {
-                        json = JSONObject.fromObject(FileUtils.readFileToString(config, "UTF-8"));
+                        json = JSONObject.fromObject(FileUtils.readFileToString(config, charecterSet));
                         auths = json.getJSONObject("auths");
                     } else {
                         config = new File(System.getProperty("user.home"), ".dockercfg");
                         if (config.exists()) {
-                            auths = json = JSONObject.fromObject(FileUtils.readFileToString(config, "UTF-8"));
+                            auths = json = JSONObject.fromObject(FileUtils.readFileToString(config, charecterSet));
                         } else {
                             // Use legacy .dockercfg to ensure this works well with pre-1.7 docker client
                             // client will pick this one if .docker/config.json does not yet exists
@@ -99,7 +100,7 @@ public final class DockerRegistryToken implements Serializable {
                             .accumulate("auth", getToken())
                             .accumulate("email", getEmail()));
                     
-                    FileUtils.writeStringToFile(config, json.toString(2), "UTF-8");
+                    FileUtils.writeStringToFile(config, json.toString(2), charecterSet);
                 }
                 return null;
             }

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -34,22 +34,25 @@ import org.junit.Test;
  */
 public class DockerRegistryEndpointTest {
 
+	private static final String indexUrl = "https://index.docker.io/v1/";
+	private static final String dockerUrl = "https://docker.acme.com";
+	
     @Test
     public void testParse() throws Exception {
-        assertRegistry("https://index.docker.io/v1/", "acme/test");
-        assertRegistry("https://index.docker.io/v1/", "busybox");
+        assertRegistry(indexUrl, "acme/test");
+        assertRegistry(indexUrl, "busybox");
         assertRegistry("https://docker.acme.com:8080", "docker.acme.com:8080/acme/test");
-        assertRegistry("https://docker.acme.com", "docker.acme.com/acme/test");
-        assertRegistry("https://docker.acme.com", "docker.acme.com/busybox");
+        assertRegistry(dockerUrl, "docker.acme.com/acme/test");
+        assertRegistry(dockerUrl, "docker.acme.com/busybox");
     }
 
     @Test
     public void testParseWithTags() throws Exception {
-        assertRegistry("https://index.docker.io/v1/", "acme/test:tag");
-        assertRegistry("https://index.docker.io/v1/", "busybox:tag");
+        assertRegistry(indexUrl, "acme/test:tag");
+        assertRegistry(indexUrl, "busybox:tag");
         assertRegistry("https://docker.acme.com:8080", "docker.acme.com:8080/acme/test:tag");
-        assertRegistry("https://docker.acme.com", "docker.acme.com/acme/test:tag");
-        assertRegistry("https://docker.acme.com", "docker.acme.com/busybox:tag");
+        assertRegistry(dockerUrl, "docker.acme.com/acme/test:tag");
+        assertRegistry(dockerUrl, "docker.acme.com/busybox:tag");
     }
 
     private void assertRegistry(String url, String repo) throws IOException {

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpointTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertThat;
  */
 public class DockerServerEndpointTest {
     
+	private static final String missing = "missing";
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
@@ -72,10 +73,10 @@ public class DockerServerEndpointTest {
         KeyMaterial keyMaterial = factory.materialize();
         FilePath path = null;
         try {
-            assertThat(keyMaterial.env().get("DOCKER_HOST", "missing"), is("tcp://localhost:2736"));
-            assertThat(keyMaterial.env().get("DOCKER_TLS_VERIFY", "missing"), is("1"));
-            assertThat(keyMaterial.env().get("DOCKER_CERT_PATH", "missing"), not("missing"));
-            path = new FilePath(channel, keyMaterial.env().get("DOCKER_CERT_PATH", "missing"));
+            assertThat(keyMaterial.env().get("DOCKER_HOST", missing), is("tcp://localhost:2736"));
+            assertThat(keyMaterial.env().get("DOCKER_TLS_VERIFY", missing), is("1"));
+            assertThat(keyMaterial.env().get("DOCKER_CERT_PATH", missing), not(missing));
+            path = new FilePath(channel, keyMaterial.env().get("DOCKER_CERT_PATH", missing));
             assertThat(path.child("key.pem").readToString(), is("a"));
             assertThat(path.child("cert.pem").readToString(), is("b"));
             assertThat(path.child("ca.pem").readToString(), is("c"));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1192 -   String literals should not be duplicated" information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192


Please let me know if you have any questions.
Sameer Misger