### PR TITLE
[JENKINS-39181] Invalid fully qualified image name when registry URL specified

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -228,8 +228,13 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
      * @return the full registry:port/namespace/name string
      * @throws IOException
      */
-    public String imageName(String userAndRepo) throws IOException {
-        if (url==null)    return userAndRepo;
+    public String imageName(@Nonnull String userAndRepo) throws IOException {
+        if (userAndRepo == null) {
+            throw new IllegalArgumentException("Image name cannot be null.");
+        }
+        if (url == null) {
+            return userAndRepo;
+        }
         URL effectiveUrl = getEffectiveUrl();
 
         StringBuilder s = new StringBuilder(effectiveUrl.getHost());

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -236,6 +236,9 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
         if (effectiveUrl.getPort() > 0 && effectiveUrl.getDefaultPort() != effectiveUrl.getPort()) {
             s.append(':').append(effectiveUrl.getPort());
         }
+        if (userAndRepo.startsWith(String.valueOf(s))) {
+            return userAndRepo;
+        }
         return s.append('/').append(userAndRepo).toString();
     }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -52,6 +52,12 @@ public class DockerRegistryEndpointTest {
         assertRegistry("https://docker.acme.com", "docker.acme.com/busybox:tag");
     }
 
+    @Test
+    public void testParseFullyQualifiedImageName() throws Exception {
+        assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("private-repo:5000/test-image"));
+        assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("test-image"));
+    }
+
     private void assertRegistry(String url, String repo) throws IOException {
         assertEquals(url, DockerRegistryEndpoint.fromImageName(repo, null).getEffectiveUrl().toString());
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Carlos Sanchez <carlos@apache.org>
@@ -52,10 +53,23 @@ public class DockerRegistryEndpointTest {
         assertRegistry("https://docker.acme.com", "docker.acme.com/busybox:tag");
     }
 
+    @Issue("JENKINS-39181")
     @Test
     public void testParseFullyQualifiedImageName() throws Exception {
         assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("private-repo:5000/test-image"));
         assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("test-image"));
+    }
+
+    @Issue("JENKINS-39181")
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseNullImageName() throws Exception {
+        new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName(null);
+    }
+
+    @Issue("JENKINS-39181")
+    @Test(expected = IllegalArgumentException.class)
+    public void testParseNullUrlAndImageName() throws Exception {
+        new DockerRegistryEndpoint(null, null).imageName(null);
     }
 
     private void assertRegistry(String url, String repo) throws IOException {


### PR DESCRIPTION
This issue was discovered in the docker-workflow-plugin. 
Given the following pipeline code:

`docker.withRegistry('http://localhost:5000/') {`
`def dockerImage = docker.image('localhost:5000/test-image')`
`dockerImage.inside {`
`echo "container running on ${port}"`
`}`
`}`

The rendered "docker pull" command incorrectly builds the qualified image name as: 
_localhost:5000/localhost:5000/test-image_

This PR adds a condition to check whether or not the image name already contains the registry prefix to avoid appending again.

cc: @genehand
