### PR TITLE
remove check for default port! it should always set the port. This is…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -238,7 +238,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
         URL effectiveUrl = getEffectiveUrl();
 
         StringBuilder s = new StringBuilder(effectiveUrl.getHost());
-        if (effectiveUrl.getPort() > 0 && effectiveUrl.getDefaultPort() != effectiveUrl.getPort()) {
+        if (effectiveUrl.getPort() > 0 ) {
             s.append(':').append(effectiveUrl.getPort());
         }
         if (userAndRepo.startsWith(String.valueOf(s))) {


### PR DESCRIPTION
… important for private registries with tricky SSL Settings and Reverse Proxy Settings.