### PR TITLE
Fix PCT Test Failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,6 @@
       <version>2.1.11</version>
     </dependency>
     <dependency>
-      <groupId>args4j</groupId>
-      <artifactId>args4j</artifactId>
-      <version>2.0.31</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authentication-tokens</artifactId>
       <version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.580.3</jenkins.version>
+    <jenkins.version>1.590</jenkins.version>
     <java.level>6</java.level>
   </properties>
 
@@ -54,6 +54,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
       <version>2.1.11</version>
+    </dependency>
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+      <version>2.0.31</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.590</jenkins.version>
+    <jenkins.version>1.609.3</jenkins.version>
     <java.level>6</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.22</version>
+      <version>2.1.11</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
@@ -57,6 +57,9 @@ public class DockerServerCredentialsTest {
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
         DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", "", "", "");
         store.addDomain(domain, credentials);
+
+        j.submit(j.createWebClient().goTo("credentials/store/system/domain/" + domain.getName() + "/credential/"+credentials.getId()+"/update")
+                .getFormByName("update"));
         
         j.assertEqualDataBoundBeans(credentials, CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(IdCredentials.class, j.getInstance(),
                 ACL.SYSTEM, new DockerServerDomainRequirement()), CredentialsMatchers.withId(credentials.getId())));
@@ -70,6 +73,9 @@ public class DockerServerCredentialsTest {
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
         DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", "a", "b", "c");
         store.addDomain(domain, credentials);
+
+        j.submit(j.createWebClient().goTo("credentials/store/system/domain/" + domain.getName() + "/credential/"+credentials.getId()+"/update")
+                .getFormByName("update"));
         
         j.assertEqualDataBoundBeans(credentials, CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(IdCredentials.class, j.getInstance(),
                 ACL.SYSTEM, new DockerServerDomainRequirement()), CredentialsMatchers.withId(credentials.getId())));

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
@@ -57,8 +57,6 @@ public class DockerServerCredentialsTest {
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
         DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", "", "", "");
         store.addDomain(domain, credentials);
-        j.submit(j.createWebClient().goTo("credential-store/domain/" + domain.getName() + "/credential/"+credentials.getId()+"/update")
-                .getFormByName("update"));
         
         j.assertEqualDataBoundBeans(credentials, CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(IdCredentials.class, j.getInstance(),
                 ACL.SYSTEM, new DockerServerDomainRequirement()), CredentialsMatchers.withId(credentials.getId())));
@@ -72,8 +70,6 @@ public class DockerServerCredentialsTest {
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
         DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", "a", "b", "c");
         store.addDomain(domain, credentials);
-        j.submit(j.createWebClient().goTo("credential-store/domain/" + domain.getName() + "/credential/"+credentials.getId()+"/update")
-                .getFormByName("update"));
         
         j.assertEqualDataBoundBeans(credentials, CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(IdCredentials.class, j.getInstance(),
                 ACL.SYSTEM, new DockerServerDomainRequirement()), CredentialsMatchers.withId(credentials.getId())));

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerDomainSpecificationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerDomainSpecificationTest.java
@@ -52,6 +52,9 @@ public class DockerServerDomainSpecificationTest {
         Domain domain = new Domain("docker", "A domain for docker credentials",
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
         store.addDomain(domain);
+
+        j.submit(j.createWebClient().goTo("credentials/store/system/domain/" + domain.getName() + "/configure")
+                .getFormByName("config"));
         
         j.assertEqualDataBoundBeans(domain, byName(store.getDomains(),domain.getName()));
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerDomainSpecificationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerDomainSpecificationTest.java
@@ -52,8 +52,6 @@ public class DockerServerDomainSpecificationTest {
         Domain domain = new Domain("docker", "A domain for docker credentials",
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
         store.addDomain(domain);
-        j.submit(j.createWebClient().goTo("credential-store/domain/" + domain.getName() + "/configure")
-                .getFormByName("config"));
         
         j.assertEqualDataBoundBeans(domain, byName(store.getDomains(),domain.getName()));
     }


### PR DESCRIPTION
With the new changes to the plugin compatibility tester, a few of this plugin's tests fail, specifically `DockerServerCredentialsTest` and `DockerServerDomainSpecificationTest`. Currently, it depends on the 1.x line of the credentials plugin. Since there were significant changes with this plugin upon the 2.x release & the plugin compat tester tests compatibility against the most recent or bundled version of the plugin, the tests are failing even though there are really no issues. I have run all the docker-commons tests using `mvn test` as well as through the plugin compat tester, and there are now no errors.

Removed the check of a url that is incompatable across a major release.  This type of check can be done in the acceptance test harness.

@reviewbybees