### PR TITLE
Remove endpoint protocol according to latest docker specific

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryToken.java
@@ -106,7 +106,7 @@ public final class DockerRegistryToken implements Serializable {
                             auths = json = new JSONObject();
                         }
                     }
-                    auths.put(endpoint.toString(), new JSONObject()
+                    auths.put(endpoint.getHost(), new JSONObject()
                             .accumulate("auth", getToken())
                             .accumulate("email", getEmail()));
                     


### PR DESCRIPTION
# Problem
I couldn't `docker.image("xxx").pull()` with `withRegistry` from Amazon ECR when I had another job in which I used `aws ecr get-login` and `docker pull` with native awscli & docker cli.

# Cause
This plugin updated `~/.docker/config.json` in a wrong format. We didn't have a problem when we used only this plugin. However, we had a problem when there was another job with native awscli.

The config file `~/.docker/config.json`is like a following.
```
{
  "auths":   {
    "1234567890.dkr.ecr.us-east-1.amazonaws.com":     {  --- (A)
      "auth": ... ,
      },
    "https://1234567890.dkr.ecr.us-east-1.amazonaws.com":     { --- (B)
      "auth": ... ,
      }
 ...
  }
}
```

A problem procedure was a following way.
1. A job which uses `aws ecr get-login`
    1. Add auth entry (A) to config.json
1. A pipeline which uses `docker.withRegistry()`
    1. Refresh auth entry (B) in config.json
    2. A auth entry (A) is used when `docker pull` in the pipeline above
    3. `docker pull`fails if a auth entry (A) is expired

Though I'm not 100% sure, according to https://github.com/moby/moby/pull/23100/files#diff-0ec52e4c7165f2740e01649dcef5867b , both docker client should uses hostname key (A), and (B) is for backward compatibility. However this plugin updated auth key (B). 