### PR TITLE
Remove icon-shim dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.15</version>
+    <version>2.36</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -19,7 +19,7 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
@@ -33,6 +33,7 @@
   <properties>
     <jenkins.version>1.642.4</jenkins.version>
     <java.level>7</java.level>
+    <jenkins-test-harness.version>2.30-20171010.153224-1</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/78 -->
   </properties>
 
   <repositories>
@@ -64,12 +65,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authentication-tokens</artifactId>
       <version>1.1</version>
-    </dependency>
-    <dependency>
-    <groupId>org.jenkins-ci.modules</groupId>
-      <artifactId>instance-identity</artifactId>
-      <version>1.3</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- for Pipeline-based unit tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,6 @@
       <version>1.3</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-      <artifactId>icon-shim</artifactId>
-      <version>1.0.3</version>
-    </dependency>
 
     <!-- for Pipeline-based unit tests -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <jenkins.version>1.642.4</jenkins.version>
     <java.level>7</java.level>
-    <jenkins-test-harness.version>2.30-20171010.153224-1</jenkins-test-harness.version> <!-- TODO https://github.com/jenkinsci/jenkins-test-harness/pull/78 -->
+    <jenkins-test-harness.version>2.30</jenkins-test-harness.version>
   </properties>
 
   <repositories>

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.plugins.docker.commons.tools;
 
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.model.TaskListener;
 import hudson.slaves.DumbSlave;
 import hudson.tools.InstallSourceProperty;
@@ -49,6 +50,7 @@ public class DockerToolInstallerTest {
     @Issue({"JENKINS-36082", "JENKINS-32790"})
     @Test
     public void smokes() throws Exception {
+        Assume.assumeFalse(Functions.isWindows());
         try {
             new URL("https://get.docker.com/").openStream().close();
         } catch (IOException x) {


### PR DESCRIPTION
Not sure why it was here—was actually older than what you would get by default anyway. Cf. https://github.com/jenkinsci/plugin-pom/pull/72.

@reviewbybees