### PR TITLE
Create directory before calling chmod

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
@@ -81,9 +81,10 @@ public class ServerKeyMaterialFactory extends KeyMaterialFactory {
 
         if (key != null && cert != null && ca != null) {
             final FilePath tempCredsDir = new FilePath(getContext().getBaseDir(), UUID.randomUUID().toString());
+            tempCredsDir.mkdirs();
 
             // protect this information from prying eyes
-            tempCredsDir.chmod(0600);
+            tempCredsDir.chmod(0700);
 
             // these file names are defined by convention by docker
             copyInto(tempCredsDir, "key.pem", key);

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpointTest.java
@@ -30,6 +30,7 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.domains.DomainSpecification;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.model.FreeStyleProject;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
@@ -76,6 +77,9 @@ public class DockerServerEndpointTest {
             assertThat(keyMaterial.env().get("DOCKER_TLS_VERIFY", "missing"), is("1"));
             assertThat(keyMaterial.env().get("DOCKER_CERT_PATH", "missing"), not("missing"));
             path = new FilePath(channel, keyMaterial.env().get("DOCKER_CERT_PATH", "missing"));
+            if (!Functions.isWindows()) {
+                assertThat(path.mode() & 0777, is(0700));
+            }
             assertThat(path.child("key.pem").readToString(), is("a"));
             assertThat(path.child("cert.pem").readToString(), is("b"));
             assertThat(path.child("ca.pem").readToString(), is("c"));


### PR DESCRIPTION
See [JENKINS-36088](https://issues.jenkins-ci.org/browse/JENKINS-36088?focusedCommentId=322239&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-322239) and subsequent comments. Before Jenkins 2.93, calling `FilePath#chmod` on a non-existent file or directory would fail silently, now it will throw `NoSuchFileException`. There appears to be an incorrect usage here that went unnoticed because the calls to`ServerKeyMaterialFactory#copyInto` call `Files#write` which creates parent directories if they do not exist.

I'm not sure why `DockerServerCredentialsBindingTest#basics` passes without this change. It runs [basics-step1.sh](https://github.com/jenkinsci/docker-commons-plugin/blob/master/src/test/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBindingTest/basics-step1.sh) which checks folder and file permissions in a build and asserts that the build succeeds. The test passes locally for me no matter what permissions are passed to `FilePath#chmod` in `ServerKeyMaterialFactory`.

@reviewbybees 