### PR TITLE
JENKINS-48674: downloads image for newer version from download.docker.com

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
@@ -42,6 +42,7 @@ import org.junit.Assume;
 import org.junit.Rule;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 public class DockerToolInstallerTest {
 
@@ -49,20 +50,21 @@ public class DockerToolInstallerTest {
     public JenkinsRule r = new JenkinsRule();
 
     @Issue({"JENKINS-48674"})
+    @WithoutJenkins
     @Test
     public void testImageUrl() throws MalformedURLException {
-        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "1.10.0"));
-        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","1.10.0"));
-        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","1.10.0"));
-        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "17.05.0-ce"));
-        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","17.05.0-ce"));
-        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","17.05.0-ce"));
-        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "latest"));
-        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","latest"));
-        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","latest"));
-        assertEquals(new URL("https://download.docker.com/linux/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "17.09.0-ce"));
-        assertEquals(new URL("https://download.docker.com/win/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","17.09.0-ce"));
-        assertEquals(new URL("https://download.docker.com/mac/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","17.09.0-ce"));
+        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "1.10.0"));
+        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("win/x86_64","1.10.0"));
+        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","1.10.0"));
+        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "17.05.0-ce"));
+        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("win/x86_64","17.05.0-ce"));
+        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","17.05.0-ce"));
+        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "latest"));
+        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("win/x86_64","latest"));
+        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","latest"));
+        assertEquals(new URL("https://download.docker.com/linux/static/edge/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/win/static/edge/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("win/x86_64","17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/mac/static/edge/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","17.09.0-ce"));
     }
 
     @Issue({"JENKINS-36082", "JENKINS-32790", "JENKINS-48674"})

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
@@ -31,6 +31,7 @@ import hudson.tools.InstallSourceProperty;
 import hudson.util.StreamTaskListener;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import org.apache.commons.io.output.TeeOutputStream;
@@ -47,7 +48,24 @@ public class DockerToolInstallerTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
-    @Issue({"JENKINS-36082", "JENKINS-32790"})
+    @Issue({"JENKINS-48674"})
+    @Test
+    public void testImageUrl() throws MalformedURLException {
+        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "1.10.0"));
+        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","1.10.0"));
+        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-1.10.0"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","1.10.0"));
+        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "17.05.0-ce"));
+        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","17.05.0-ce"));
+        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-17.05.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","17.05.0-ce"));
+        assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "latest"));
+        assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","latest"));
+        assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","latest"));
+        assertEquals(new URL("https://download.docker.com/linux/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/static/stable/x86_64", "17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/win/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("win/static/stable/x86_64","17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/mac/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/static/stable/x86_64","17.09.0-ce"));
+    }
+
+    @Issue({"JENKINS-36082", "JENKINS-32790", "JENKINS-48674"})
     @Test
     public void smokes() throws Exception {
         Assume.assumeFalse(Functions.isWindows());
@@ -56,35 +74,40 @@ public class DockerToolInstallerTest {
         } catch (IOException x) {
             Assume.assumeNoException("Cannot contact get.docker.com, perhaps test machine is not online", x);
         }
+        try {
+            new URL("https://download.docker.com/").openStream().close();
+        } catch (IOException x) {
+            Assume.assumeNoException("Cannot contact download.docker.com, perhaps test machine is not online", x);
+        }
         r.jenkins.getDescriptorByType(DockerTool.DescriptorImpl.class).setInstallations(
             new DockerTool("latest", "", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(new DockerToolInstaller("", "latest"))))),
-            new DockerTool("1.10.0", "", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(new DockerToolInstaller("", "1.10.0"))))));
+            new DockerTool("1.10.0", "", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(new DockerToolInstaller("", "1.10.0"))))),
+            new DockerTool("17.09.1-ce", "", Collections.singletonList(new InstallSourceProperty(Collections.singletonList(new DockerToolInstaller("", "17.09.1-ce.tgz"))))));
         DumbSlave slave = r.createOnlineSlave();
         FilePath toolDir = slave.getRootPath().child("tools/org.jenkinsci.plugins.docker.commons.tools.DockerTool");
-        FilePath exe10 = toolDir.child("1.10.0/bin/docker");
+
+        FilePath exe10 = downloadDocker(slave, toolDir, "1.10.0");
+        FilePath exeLatest = downloadDocker(slave, toolDir, "latest");
+        FilePath exe17 = downloadDocker(slave, toolDir, "17.09.1-ce");
+
+        assertThat("we do not have any extra files in here", toolDir.list("**"), arrayContainingInAnyOrder(exe10, toolDir.child("1.10.0/.timestamp"), exeLatest, toolDir.child("latest/.timestamp"), exe17, toolDir.child("17.09.1-ce/.timestamp")));
+    }
+
+    private FilePath downloadDocker(DumbSlave slave, FilePath toolDir, String version) throws IOException, InterruptedException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         TaskListener l = new StreamTaskListener(new TeeOutputStream(baos, System.err));
-        // Download 1.10.0 for first time:
-        assertEquals(exe10.getRemote(), DockerTool.getExecutable("1.10.0", slave, l, null));
-        assertTrue(exe10.exists());
-        assertThat(baos.toString(), containsString(Messages.DockerToolInstaller_downloading_docker_client_("1.10.0")));
+
+        FilePath exe = toolDir.child(version+"/bin/docker");
+        // Download for first time:
+        assertEquals(exe.getRemote(), DockerTool.getExecutable(version, slave, l, null));
+        assertTrue(exe.exists());
+        assertThat(baos.toString(), containsString(Messages.DockerToolInstaller_downloading_docker_client_(version)));
         // Next time we do not need to download:
         baos.reset();
-        assertEquals(exe10.getRemote(), DockerTool.getExecutable("1.10.0", slave, l, null));
-        assertTrue(exe10.exists());
-        assertThat(baos.toString(), not(containsString(Messages.DockerToolInstaller_downloading_docker_client_("1.10.0"))));
-        // Download latest for the first time:
-        baos.reset();
-        FilePath exeLatest = toolDir.child("latest/bin/docker");
-        assertEquals(exeLatest.getRemote(), DockerTool.getExecutable("latest", slave, l, null));
-        assertTrue(exeLatest.exists());
-        assertThat(baos.toString(), containsString(Messages.DockerToolInstaller_downloading_docker_client_("latest")));
-        // Next time we do not need to download:
-        baos.reset();
-        assertEquals(exeLatest.getRemote(), DockerTool.getExecutable("latest", slave, l, null));
-        assertTrue(exeLatest.exists());
-        assertThat(baos.toString(), not(containsString(Messages.DockerToolInstaller_downloading_docker_client_("latest"))));
-        assertThat("we do not have any extra files in here", toolDir.list("**"), arrayContainingInAnyOrder(exe10, toolDir.child("1.10.0/.timestamp"), exeLatest, toolDir.child("latest/.timestamp")));
+        assertEquals(exe.getRemote(), DockerTool.getExecutable(version, slave, l, null));
+        assertTrue(exe.exists());
+        assertThat(baos.toString(), not(containsString(Messages.DockerToolInstaller_downloading_docker_client_(version))));
+        return exe;
     }
 
 }


### PR DESCRIPTION
Update the plugin to use the new host and url scheme while preserving access to older images (pre 17.05.0-ce).

https://issues.jenkins-ci.org/browse/JENKINS-48674
  