### PR TITLE
JENKINS-48783: the macOs version of stat uses the '-f', not the '-c', argument to specify the format

### DIFF
--- a/src/test/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBindingTest/basics-step1.sh
+++ b/src/test/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBindingTest/basics-step1.sh
@@ -1,17 +1,25 @@
 #!/bin/sh
 set -e -x
 
+if [ `uname` = 'Darwin' ] ; then
+  permission_fmt='-f %Lp'
+  size_fmt='-f %z'
+else
+  permission_fmt='-c %a'
+  size_fmt='-c %s'
+fi
+
 # check permissions on the credentials dir and its parent
-[ $(stat -c %a "$DOCKER_CERT_PATH")    = 700 ]
-[ $(stat -c %a "$DOCKER_CERT_PATH"/..) = 700 ]
+[ $(stat $permission_fmt "$DOCKER_CERT_PATH")    = 700 ]
+[ $(stat $permission_fmt "$DOCKER_CERT_PATH"/..) = 700 ]
 
 # check permissions and content of the certificate files
-[ $(stat -c %a "$DOCKER_CERT_PATH/key.pem")  = 600 ]
-[ $(stat -c %a "$DOCKER_CERT_PATH/cert.pem") = 600 ]
-[ $(stat -c %a "$DOCKER_CERT_PATH/ca.pem")   = 600 ]
-[ $(stat -c %s "$DOCKER_CERT_PATH/key.pem")  = 9 ]
-[ $(stat -c %s "$DOCKER_CERT_PATH/cert.pem") = 17 ]
-[ $(stat -c %s "$DOCKER_CERT_PATH/ca.pem")   = 19 ]
+[ $(stat $permission_fmt "$DOCKER_CERT_PATH/key.pem")  = 600 ]
+[ $(stat $permission_fmt "$DOCKER_CERT_PATH/cert.pem") = 600 ]
+[ $(stat $permission_fmt "$DOCKER_CERT_PATH/ca.pem")   = 600 ]
+[ $(stat $size_fmt "$DOCKER_CERT_PATH/key.pem")  = 9 ]
+[ $(stat $size_fmt "$DOCKER_CERT_PATH/cert.pem") = 17 ]
+[ $(stat $size_fmt "$DOCKER_CERT_PATH/ca.pem")   = 19 ]
 
 # keep location of the certificate dir for the next step
 echo "$DOCKER_CERT_PATH" > cert-path


### PR DESCRIPTION
it also has different format string.