### PR TITLE
[JENKINS-48437] Authorization for Docker Endpoint

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -38,13 +38,16 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Item;
+import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.queue.Tasks;
 import hudson.remoting.VirtualChannel;
 import hudson.util.ListBoxModel;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
 
+import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -184,7 +187,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
 
         // look for subtypes that know how to create a token, such as Google Container Registry
         return AuthenticationTokens.convert(DockerRegistryToken.class, firstOrNull(CredentialsProvider.lookupCredentials(
-                IdCredentials.class, context, Jenkins.getAuthentication(),requirements),
+                IdCredentials.class, context, Jenkins.getAuthentication(), requirements),
                 allOf(AuthenticationTokens.matcher(DockerRegistryToken.class), withId(credentialsId))));
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -295,7 +295,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
      * @param workspace a workspace being used for operations ({@link WorkspaceList#tempDir} will be applied)
      * @param dockerExecutable as in {@link DockerTool#getExecutable}, with a 1.8+ client
      */
-    public KeyMaterialFactory newKeyMaterialFactory(@CheckForNull Run context, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener, @Nonnull String dockerExecutable) throws IOException, InterruptedException {
+    public KeyMaterialFactory newKeyMaterialFactory(@CheckForNull Run context, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull EnvVars env, @Nonnull TaskListener listener, @Nonnull String dockerExecutable) throws IOException, InterruptedException {
         if (credentialsId == null) {
             return KeyMaterialFactory.NULL; // nothing needed to be done
         }
@@ -303,7 +303,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
         if (token == null) {
             throw new AbortException("Could not find credentials matching " + credentialsId);
         }
-        return token.newKeyMaterialFactory(getEffectiveUrl(), workspace, launcher, listener, dockerExecutable);
+        return token.newKeyMaterialFactory(getEffectiveUrl(), workspace, launcher, env, listener, dockerExecutable);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
@@ -102,7 +102,10 @@ public class DockerServerEndpoint extends AbstractDescribableImpl<DockerServerEn
     /**
      * Makes the key materials available locally and returns {@link KeyMaterialFactory} that gives you the parameters
      * needed to access it.
+     * 
+     * @deprecated Call {@link #newKeyMaterialFactory(Run, VirtualChannel)}
      */
+    @Deprecated
     public KeyMaterialFactory newKeyMaterialFactory(@Nonnull Item context, @Nonnull VirtualChannel target) throws IOException, InterruptedException {
         // as a build step, your access to credentials are constrained by what the build
         // can access, hence Jenkins.getAuthentication()

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.docker.commons.credentials;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Base64;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -36,7 +37,6 @@ import hudson.model.*;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import jenkins.model.Jenkins;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.Charsets;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -111,7 +111,7 @@ public class DockerRegistryEndpointTest {
             DockerRegistryToken token = new DockerRegistryEndpoint("https://index.docker.io/v1/", globalCredentialsId).getToken(item);
             Assert.assertNotNull(token);
             Assert.assertEquals("user", token.getEmail());
-            Assert.assertEquals(Base64.encodeBase64String("user:password".getBytes(Charsets.UTF_8)), token.getToken());
+            Assert.assertEquals(Base64.getEncoder().encodeToString("user:password".getBytes(Charsets.UTF_8)), token.getToken());
         }
     }
 
@@ -137,7 +137,7 @@ public class DockerRegistryEndpointTest {
                     globalCredentialsId).getToken(new FreeStyleBuild(item));
             Assert.assertNotNull(token);
             Assert.assertEquals("user", token.getEmail());
-            Assert.assertEquals(Base64.encodeBase64String("user:password".getBytes(Charsets.UTF_8)), token.getToken());
+            Assert.assertEquals(Base64.getEncoder().encodeToString("user:password".getBytes(Charsets.UTF_8)), token.getToken());
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 /**
  * @author Carlos Sanchez <carlos@apache.org>
@@ -54,6 +55,7 @@ public class DockerRegistryEndpointTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
+    @WithoutJenkins
     public void testParse() throws Exception {
         assertRegistry("https://index.docker.io/v1/", "acme/test");
         assertRegistry("https://index.docker.io/v1/", "busybox");
@@ -63,6 +65,7 @@ public class DockerRegistryEndpointTest {
     }
 
     @Test
+    @WithoutJenkins
     public void testParseWithTags() throws Exception {
         assertRegistry("https://index.docker.io/v1/", "acme/test:tag");
         assertRegistry("https://index.docker.io/v1/", "busybox:tag");
@@ -73,6 +76,7 @@ public class DockerRegistryEndpointTest {
 
     @Issue("JENKINS-39181")
     @Test
+    @WithoutJenkins
     public void testParseFullyQualifiedImageName() throws Exception {
         assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("private-repo:5000/test-image"));
         assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("test-image"));
@@ -80,12 +84,14 @@ public class DockerRegistryEndpointTest {
 
     @Issue("JENKINS-39181")
     @Test(expected = IllegalArgumentException.class)
+    @WithoutJenkins
     public void testParseNullImageName() throws Exception {
         new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName(null);
     }
 
     @Issue("JENKINS-39181")
     @Test(expected = IllegalArgumentException.class)
+    @WithoutJenkins
     public void testParseNullUrlAndImageName() throws Exception {
         new DockerRegistryEndpoint(null, null).imageName(null);
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -98,31 +98,6 @@ public class DockerRegistryEndpointTest {
 
     @Issue("JENKINS-48437")
     @Test
-    public void testGetTokenForItem() throws IOException {
-        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
-        MockAuthorizationStrategy auth = new MockAuthorizationStrategy()
-                .grant(Jenkins.READ).everywhere().to("alice")
-                .grant(Computer.BUILD).everywhere().to("alice")
-                .grant(Item.CONFIGURE).everywhere().to("alice");
-        j.jenkins.setAuthorizationStrategy(auth);
-
-        String globalCredentialsId = "global-creds";
-        IdCredentials credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
-                globalCredentialsId, "test-global-creds", "user", "password");
-        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
-
-        FreeStyleProject item = j.createFreeStyleProject("testGetToken");
-
-        try (ACLContext as = ACL.as(User.getById("alice", false))) {
-            DockerRegistryToken token = new DockerRegistryEndpoint("https://index.docker.io/v1/", globalCredentialsId).getToken(item);
-            Assert.assertNotNull(token);
-            Assert.assertEquals("user", token.getEmail());
-            Assert.assertEquals(Base64.getEncoder().encodeToString("user:password".getBytes(Charsets.UTF_8)), token.getToken());
-        }
-    }
-
-    @Issue("JENKINS-48437")
-    @Test
     public void testGetTokenForRun() throws IOException {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         MockAuthorizationStrategy auth = new MockAuthorizationStrategy()
@@ -136,7 +111,7 @@ public class DockerRegistryEndpointTest {
                 globalCredentialsId, "test-global-creds", "user", "password");
         CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
 
-        FreeStyleProject item = j.createFreeStyleProject("testGetToken");
+        FreeStyleProject item = j.createFreeStyleProject();
 
         try (ACLContext as = ACL.as(User.getById("alice", false))) {
             DockerRegistryToken token = new DockerRegistryEndpoint("https://index.docker.io/v1/",


### PR DESCRIPTION
[JENKINS-48437](https://issues.jenkins-ci.org/browse/JENKINS-48437)

Proposed a fix for the issue with the method that retrieves the credentials to get the DockerRegistryToken.
Add implementation accepting a `Run` as context (and using [CredentialsProvider.findCredentialById](https://github.com/jenkinsci/credentials-plugin/blob/master/src/main/java/com/cloudbees/plugins/credentials/CredentialsProvider.java#L855-L871)) that can be later leverage by docker-workflow.

@reviewbybees 