### PR TITLE
[JENKINS-41880] Synchronise on Fingerprint

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprintAction.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprintAction.java
@@ -96,20 +96,20 @@ public class DockerFingerprintAction implements RunAction2, IconSpec {
     public @CheckForNull String getFingerprintHash(@CheckForNull String imageId) {
         return (imageId != null) ? DockerFingerprints.getFingerprintHash(imageId) : null;
     }
-    
+
     @Restricted(NoExternalUse.class)
     public @CheckForNull Fingerprint getFingerprint(@CheckForNull String imageId) {
         if (imageId == null) {
             return null;
         }
-        
+
         try {
             return DockerFingerprints.of(imageId);
         } catch (IOException ex) {
             return null; // nothing to do in web UI - return null as well
         }
     }
-    
+
     public List<DockerFingerprintFacet> getDockerFacets(String imageId) {
         List<DockerFingerprintFacet> res = new LinkedList<DockerFingerprintFacet>();
         final Fingerprint fp = getFingerprint(imageId);
@@ -125,9 +125,9 @@ public class DockerFingerprintAction implements RunAction2, IconSpec {
 
     /**
      * Adds an action with a reference to fingerprint if required. It's
-     * recommended to call the method from {
+     * recommended to call the method from {@link hudson.BulkChange}
+     * transaction to avoid saving the {@link Run} multiple times.
      *
-     * @BulkChange} transaction to avoid saving the {@link Run} multiple times.
      * @param fp Fingerprint
      * @param imageId ID of the docker image
      * @param run Run to be updated
@@ -140,7 +140,7 @@ public class DockerFingerprintAction implements RunAction2, IconSpec {
                 action = new DockerFingerprintAction();
                 run.addAction(action);
             }
-            
+
             if (action.imageIDs.add(imageId)) {
                 run.save();
             } // else no need to save updates

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprintAction.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprintAction.java
@@ -96,20 +96,20 @@ public class DockerFingerprintAction implements RunAction2, IconSpec {
     public @CheckForNull String getFingerprintHash(@CheckForNull String imageId) {
         return (imageId != null) ? DockerFingerprints.getFingerprintHash(imageId) : null;
     }
-
+    
     @Restricted(NoExternalUse.class)
     public @CheckForNull Fingerprint getFingerprint(@CheckForNull String imageId) {
         if (imageId == null) {
             return null;
         }
-
+        
         try {
             return DockerFingerprints.of(imageId);
         } catch (IOException ex) {
             return null; // nothing to do in web UI - return null as well
         }
     }
-
+    
     public List<DockerFingerprintFacet> getDockerFacets(String imageId) {
         List<DockerFingerprintFacet> res = new LinkedList<DockerFingerprintFacet>();
         final Fingerprint fp = getFingerprint(imageId);
@@ -125,9 +125,9 @@ public class DockerFingerprintAction implements RunAction2, IconSpec {
 
     /**
      * Adds an action with a reference to fingerprint if required. It's
-     * recommended to call the method from {@link hudson.BulkChange}
-     * transaction to avoid saving the {@link Run} multiple times.
+     * recommended to call the method from {
      *
+     * @BulkChange} transaction to avoid saving the {@link Run} multiple times.
      * @param fp Fingerprint
      * @param imageId ID of the docker image
      * @param run Run to be updated
@@ -140,7 +140,7 @@ public class DockerFingerprintAction implements RunAction2, IconSpec {
                 action = new DockerFingerprintAction();
                 run.addAction(action);
             }
-
+            
             if (action.imageIDs.add(imageId)) {
                 run.save();
             } // else no need to save updates

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
@@ -257,6 +257,7 @@ public class DockerFingerprints {
         long timestamp = System.currentTimeMillis();
         if (ancestorImageId != null) {
             Fingerprint f = forImage(run, ancestorImageId);
+            synchronized (f) {
             Collection<FingerprintFacet> facets = f.getFacets();
             DockerDescendantFingerprintFacet descendantFacet = null;
             for (FingerprintFacet facet : facets) {
@@ -278,8 +279,10 @@ public class DockerFingerprints {
             } finally {
                 bc.abort();
             }
+            }
         }
         Fingerprint f = forImage(run, descendantImageId);
+        synchronized (f) {
         Collection<FingerprintFacet> facets = f.getFacets();
         DockerAncestorFingerprintFacet ancestorFacet = null;
         for (FingerprintFacet facet : facets) {
@@ -302,6 +305,7 @@ public class DockerFingerprints {
             bc.commit();
         } finally {
             bc.abort();
+        }
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
@@ -26,8 +26,12 @@ package org.jenkinsci.plugins.docker.commons.fingerprint;
 import hudson.BulkChange;
 import hudson.model.Fingerprint;
 import hudson.model.Run;
+import jenkins.model.FingerprintFacet;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,10 +39,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import jenkins.model.FingerprintFacet;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Entry point into fingerprint related functionalities in Docker.
@@ -254,54 +254,56 @@ public class DockerFingerprints {
      * @param run the build in which the image building occurred
      */
     public static void addFromFacet(@CheckForNull String ancestorImageId, @Nonnull String descendantImageId, @Nonnull Run<?,?> run) throws IOException {
-        long timestamp = System.currentTimeMillis();
-        if (ancestorImageId != null) {
-            Fingerprint f = forImage(run, ancestorImageId);
+        synchronized (run.getParent()) {
+            long timestamp = System.currentTimeMillis();
+            if (ancestorImageId != null) {
+                Fingerprint f = forImage(run, ancestorImageId);
+                Collection<FingerprintFacet> facets = f.getFacets();
+                DockerDescendantFingerprintFacet descendantFacet = null;
+                for (FingerprintFacet facet : facets) {
+                    if (facet instanceof DockerDescendantFingerprintFacet) {
+                        descendantFacet = (DockerDescendantFingerprintFacet) facet;
+                        break;
+                    }
+                }
+                BulkChange bc = new BulkChange(f);
+                try {
+                    if (descendantFacet == null) {
+                        descendantFacet = new DockerDescendantFingerprintFacet(f, timestamp, ancestorImageId);
+                        facets.add(descendantFacet);
+                    }
+                    descendantFacet.addDescendantImageId(descendantImageId);
+                    descendantFacet.addFor(run);
+                    DockerFingerprintAction.addToRun(f, ancestorImageId, run);
+                    bc.commit();
+                } finally {
+                    bc.abort();
+                }
+            }
+            Fingerprint f = forImage(run, descendantImageId);
             Collection<FingerprintFacet> facets = f.getFacets();
-            DockerDescendantFingerprintFacet descendantFacet = null;
+            DockerAncestorFingerprintFacet ancestorFacet = null;
             for (FingerprintFacet facet : facets) {
-                if (facet instanceof DockerDescendantFingerprintFacet) {
-                    descendantFacet = (DockerDescendantFingerprintFacet) facet;
+                if (facet instanceof DockerAncestorFingerprintFacet) {
+                    ancestorFacet = (DockerAncestorFingerprintFacet) facet;
                     break;
                 }
             }
             BulkChange bc = new BulkChange(f);
             try {
-                if (descendantFacet == null) {
-                    descendantFacet = new DockerDescendantFingerprintFacet(f, timestamp, ancestorImageId);
-                    facets.add(descendantFacet);
+                if (ancestorFacet == null) {
+                    ancestorFacet = new DockerAncestorFingerprintFacet(f, timestamp, descendantImageId);
+                    facets.add(ancestorFacet);
                 }
-                descendantFacet.addDescendantImageId(descendantImageId);
-                descendantFacet.addFor(run);
-                DockerFingerprintAction.addToRun(f, ancestorImageId, run);
+                if (ancestorImageId != null) {
+                    ancestorFacet.addAncestorImageId(ancestorImageId);
+                }
+                ancestorFacet.addFor(run);
+                DockerFingerprintAction.addToRun(f, descendantImageId, run);
                 bc.commit();
             } finally {
                 bc.abort();
             }
-        }
-        Fingerprint f = forImage(run, descendantImageId);
-        Collection<FingerprintFacet> facets = f.getFacets();
-        DockerAncestorFingerprintFacet ancestorFacet = null;
-        for (FingerprintFacet facet : facets) {
-            if (facet instanceof DockerAncestorFingerprintFacet) {
-                ancestorFacet = (DockerAncestorFingerprintFacet) facet;
-                break;
-            }
-        }
-        BulkChange bc = new BulkChange(f);
-        try {
-            if (ancestorFacet == null) {
-                ancestorFacet = new DockerAncestorFingerprintFacet(f, timestamp, descendantImageId);
-                facets.add(ancestorFacet);
-            }
-            if (ancestorImageId != null) {
-                ancestorFacet.addAncestorImageId(ancestorImageId);
-            }
-            ancestorFacet.addFor(run);
-            DockerFingerprintAction.addToRun(f, descendantImageId, run);
-            bc.commit();
-        } finally {
-            bc.abort();
         }
     }
 


### PR DESCRIPTION
I am not sure this makes any sense. I am just trying to solve this
issue: https://issues.jenkins-ci.org/browse/JENKINS-41880

My thoughts:

This is likely caused by changing the finger prints, the finger prints
are scoped to the project (right?). If this is the case synchronising on
the project could make sense. Also `addFromFacet` should not be a
performance killer and rather quick.

The alternative would be for me to synchronise the complete access to the method.

WDYT?