### PR TITLE
Use secretTextarea for PKI certificates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>docker-commons</artifactId>
-  <version>1.15-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Docker Commons Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>docker-commons</artifactId>
-  <version>1.14</version>
+  <version>1.15-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Docker Commons Plugin</name>
@@ -27,7 +27,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>docker-commons-1.14</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>authentication-tokens</artifactId>
       <version>1.3</version>
     </dependency>
+    <dependency>
+      <groupId>io.jenkins.temp.jelly</groupId>
+      <artifactId>multiline-secrets-ui</artifactId>
+      <version>1.0</version>
+    </dependency>
 
     <!-- for Pipeline-based unit tests -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>docker-commons</artifactId>
-  <version>${revision}${changelist}</version>
+  <version>1.14</version>
   <packaging>hpi</packaging>
 
   <name>Docker Commons Plugin</name>
@@ -27,7 +27,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>${scmTag}</tag>
+    <tag>docker-commons-1.14</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <revision>1.14</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.171</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -66,11 +66,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authentication-tokens</artifactId>
       <version>1.3</version>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.temp.jelly</groupId>
-      <artifactId>multiline-secrets-ui</artifactId>
-      <version>1.0</version>
     </dependency>
 
     <!-- for Pipeline-based unit tests -->

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -189,6 +189,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
             requirements = Collections.<DomainRequirement>singletonList(new HostnameRequirement(getEffectiveUrl().getHost()));
         } catch (IOException e) {
             // shrug off this error and move on. We are matching with ID anyway.
+            LOGGER.log(Level.FINE, "Unable to add domain requirement for endpoint URL", e);
         }
 
         // look for subtypes that know how to create a token, such as Google Container Registry
@@ -215,7 +216,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
         try {
             requirements = Collections.<DomainRequirement>singletonList(new HostnameRequirement(getEffectiveUrl().getHost()));
         } catch (IOException e) {
-            LOGGER.log(Level.WARNING, "Could not initiliaze registry URL: ", e);
+            LOGGER.log(Level.FINE, "Unable to add domain requirement for endpoint URL", e);
         }
 
         return AuthenticationTokens.convert(DockerRegistryToken.class,

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -38,13 +38,16 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.Item;
+import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.model.queue.Tasks;
 import hudson.remoting.VirtualChannel;
 import hudson.util.ListBoxModel;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
 
+import org.acegisecurity.Authentication;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -184,7 +187,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
 
         // look for subtypes that know how to create a token, such as Google Container Registry
         return AuthenticationTokens.convert(DockerRegistryToken.class, firstOrNull(CredentialsProvider.lookupCredentials(
-                IdCredentials.class, context, Jenkins.getAuthentication(),requirements),
+                IdCredentials.class, context, Jenkins.getAuthentication(), requirements),
                 allOf(AuthenticationTokens.matcher(DockerRegistryToken.class), withId(credentialsId))));
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpoint.java
@@ -295,7 +295,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
      * @param workspace a workspace being used for operations ({@link WorkspaceList#tempDir} will be applied)
      * @param dockerExecutable as in {@link DockerTool#getExecutable}, with a 1.8+ client
      */
-    public KeyMaterialFactory newKeyMaterialFactory(@CheckForNull Run context, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener, @Nonnull String dockerExecutable) throws IOException, InterruptedException {
+    public KeyMaterialFactory newKeyMaterialFactory(@CheckForNull Run context, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull EnvVars env, @Nonnull TaskListener listener, @Nonnull String dockerExecutable) throws IOException, InterruptedException {
         if (credentialsId == null) {
             return KeyMaterialFactory.NULL; // nothing needed to be done
         }
@@ -303,7 +303,7 @@ public class DockerRegistryEndpoint extends AbstractDescribableImpl<DockerRegist
         if (token == null) {
             throw new AbortException("Could not find credentials matching " + credentialsId);
         }
-        return token.newKeyMaterialFactory(getEffectiveUrl(), workspace, launcher, listener, dockerExecutable);
+        return token.newKeyMaterialFactory(getEffectiveUrl(), workspace, launcher, env, listener, dockerExecutable);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
@@ -28,6 +28,8 @@ import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import hudson.Extension;
 import hudson.Util;
 import hudson.util.Secret;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.CheckForNull;
@@ -46,9 +48,9 @@ public class DockerServerCredentials extends BaseStandardCredentials {
     @CheckForNull 
     private final Secret clientKey;
     @CheckForNull 
-    private final String clientCertificate;
+    private final Secret clientCertificate;
     @CheckForNull 
-    private final String serverCaCertificate;
+    private final Secret serverCaCertificate;
 
     @DataBoundConstructor
     public DockerServerCredentials(CredentialsScope scope, String id, String description,
@@ -56,8 +58,8 @@ public class DockerServerCredentials extends BaseStandardCredentials {
                                    @CheckForNull String serverCaCertificate) {
         super(scope, id, description);
         this.clientKey = Util.fixEmptyAndTrim(clientKey) == null ? null : Secret.fromString(clientKey);
-        this.clientCertificate = Util.fixEmptyAndTrim(clientCertificate);
-        this.serverCaCertificate = Util.fixEmptyAndTrim(serverCaCertificate);
+        this.clientCertificate = Util.fixEmptyAndTrim(clientCertificate) == null ? null : Secret.fromString(clientCertificate);
+        this.serverCaCertificate = Util.fixEmptyAndTrim(serverCaCertificate) == null ? null : Secret.fromString(serverCaCertificate);
     }
 
     /**
@@ -70,6 +72,12 @@ public class DockerServerCredentials extends BaseStandardCredentials {
         return clientKey == null ? null : clientKey.getPlainText();
     }
 
+    @CheckForNull
+    @Restricted(NoExternalUse.class)
+    public Secret getClientKeySecret() {
+        return clientKey;
+    }
+
     /**
      * Gets the PEM formatted client certificate.
      * The {@code --tlscert} option in docker(1).
@@ -78,6 +86,12 @@ public class DockerServerCredentials extends BaseStandardCredentials {
      */
     @CheckForNull 
     public String getClientCertificate() {
+        return clientCertificate == null ? null : clientCertificate.getPlainText();
+    }
+
+    @CheckForNull
+    @Restricted(NoExternalUse.class)
+    public Secret getClientCertificateSecret() {
         return clientCertificate;
     }
 
@@ -89,6 +103,12 @@ public class DockerServerCredentials extends BaseStandardCredentials {
      */
     @CheckForNull 
     public String getServerCaCertificate() {
+        return serverCaCertificate == null ? null : serverCaCertificate.getPlainText();
+    }
+
+    @CheckForNull
+    @Restricted(NoExternalUse.class)
+    public Secret getServerCaCertificateSecret() {
         return serverCaCertificate;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
@@ -28,8 +28,6 @@ import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import hudson.Extension;
 import hudson.Util;
 import hudson.util.Secret;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.CheckForNull;
@@ -52,7 +50,7 @@ public class DockerServerCredentials extends BaseStandardCredentials {
     @CheckForNull 
     private final Secret serverCaCertificate;
 
-    @DataBoundConstructor
+    @Deprecated
     public DockerServerCredentials(CredentialsScope scope, String id, String description,
                                    @CheckForNull String clientKey, @CheckForNull String clientCertificate,
                                    @CheckForNull String serverCaCertificate) {
@@ -62,19 +60,23 @@ public class DockerServerCredentials extends BaseStandardCredentials {
         this.serverCaCertificate = Util.fixEmptyAndTrim(serverCaCertificate) == null ? null : Secret.fromString(serverCaCertificate);
     }
 
+    @DataBoundConstructor
+    public DockerServerCredentials(CredentialsScope scope, String id, String description,
+                                   @CheckForNull Secret clientKey, @CheckForNull Secret clientCertificate,
+                                   @CheckForNull Secret serverCaCertificate) {
+        super(scope, id, description);
+        this.clientKey = clientKey;
+        this.clientCertificate = clientCertificate;
+        this.serverCaCertificate = serverCaCertificate;
+    }
+
     /**
      * Gets the PEM formatted secret key to identify the client. The {@code --tlskey} option in docker(1)
      *
      * @return null if there's no authentication
      */
     @CheckForNull
-    public String getClientKey() {
-        return clientKey == null ? null : clientKey.getPlainText();
-    }
-
-    @CheckForNull
-    @Restricted(NoExternalUse.class)
-    public Secret getClientKeySecret() {
+    public Secret getClientKey() {
         return clientKey;
     }
 
@@ -85,13 +87,7 @@ public class DockerServerCredentials extends BaseStandardCredentials {
      * @return null if there's no authentication
      */
     @CheckForNull 
-    public String getClientCertificate() {
-        return clientCertificate == null ? null : clientCertificate.getPlainText();
-    }
-
-    @CheckForNull
-    @Restricted(NoExternalUse.class)
-    public Secret getClientCertificateSecret() {
+    public Secret getClientCertificate() {
         return clientCertificate;
     }
 
@@ -102,13 +98,7 @@ public class DockerServerCredentials extends BaseStandardCredentials {
      * @return null if there's no authentication
      */
     @CheckForNull 
-    public String getServerCaCertificate() {
-        return serverCaCertificate == null ? null : serverCaCertificate.getPlainText();
-    }
-
-    @CheckForNull
-    @Restricted(NoExternalUse.class)
-    public Secret getServerCaCertificateSecret() {
+    public Secret getServerCaCertificate() {
         return serverCaCertificate;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBinding.java
@@ -10,6 +10,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.util.Secret;
 
 public class DockerServerCredentialsBinding extends AbstractOnDiskBinding<DockerServerCredentials> {
 
@@ -26,15 +27,15 @@ public class DockerServerCredentialsBinding extends AbstractOnDiskBinding<Docker
     @Override
     protected FilePath write(DockerServerCredentials credentials, FilePath dir) throws IOException, InterruptedException {
         FilePath clientKey = dir.child("key.pem");
-        clientKey.write(credentials.getClientKey(), null);
+        clientKey.write(Secret.toString(credentials.getClientKey()), null);
         clientKey.chmod(0600);
 
         FilePath clientCert = dir.child("cert.pem");
-        clientCert.write(credentials.getClientCertificate(), null);
+        clientCert.write(Secret.toString(credentials.getClientCertificate()), null);
         clientCert.chmod(0600);
 
         FilePath serverCACert = dir.child("ca.pem");
-        serverCACert.write(credentials.getServerCaCertificate(), null);
+        serverCACert.write(Secret.toString(credentials.getServerCaCertificate()), null);
         serverCACert.chmod(0600);
 
         return dir;

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
@@ -95,7 +95,10 @@ public class DockerServerEndpoint extends AbstractDescribableImpl<DockerServerEn
     /**
      * Makes the key materials available locally for the on-going build
      * and returns {@link KeyMaterialFactory} that gives you the parameters needed to access it.
+     *
+     * @deprecated Call {@link #newKeyMaterialFactory(Run, VirtualChannel)}
      */
+    @Deprecated
     public KeyMaterialFactory newKeyMaterialFactory(@Nonnull AbstractBuild build) throws IOException, InterruptedException {
         final FilePath workspace = build.getWorkspace();
         if (workspace == null) {

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
@@ -31,7 +31,12 @@ import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import hudson.Extension;
 import hudson.FilePath;
-import hudson.model.*;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Run;
 import hudson.remoting.VirtualChannel;
 import hudson.util.ListBoxModel;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
@@ -96,7 +101,7 @@ public class DockerServerEndpoint extends AbstractDescribableImpl<DockerServerEn
         if (workspace == null) {
             throw new IllegalStateException("Build has no workspace");
         }
-        return newKeyMaterialFactory(build.getParent(), workspace.getChannel());
+        return newKeyMaterialFactory(build, workspace.getChannel());
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpoint.java
@@ -102,7 +102,10 @@ public class DockerServerEndpoint extends AbstractDescribableImpl<DockerServerEn
     /**
      * Makes the key materials available locally and returns {@link KeyMaterialFactory} that gives you the parameters
      * needed to access it.
+     * 
+     * @deprecated Call {@link #newKeyMaterialFactory(Run, VirtualChannel)}
      */
+    @Deprecated
     public KeyMaterialFactory newKeyMaterialFactory(@Nonnull Item context, @Nonnull VirtualChannel target) throws IOException, InterruptedException {
         // as a build step, your access to credentials are constrained by what the build
         // can access, hence Jenkins.getAuthentication()

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.docker.commons.impl;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.util.Secret;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterial;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterialFactory;
@@ -47,11 +48,11 @@ import java.io.IOException;
 public class ServerKeyMaterialFactory extends KeyMaterialFactory {
     
     @CheckForNull 
-    private final String key;
+    private final Secret key;
     @CheckForNull 
-    private final String cert;
+    private final Secret cert;
     @CheckForNull 
-    private final String ca;
+    private final Secret ca;
     
     private static final long serialVersionUID = 1L;
 
@@ -67,7 +68,7 @@ public class ServerKeyMaterialFactory extends KeyMaterialFactory {
         }
     }
 
-    public ServerKeyMaterialFactory(@CheckForNull String key, @CheckForNull String cert, @CheckForNull String ca) {
+    public ServerKeyMaterialFactory(@CheckForNull Secret key, @CheckForNull Secret cert, @CheckForNull Secret ca) {
         this.key = key;
         this.cert = cert;
         this.ca = ca;
@@ -82,9 +83,9 @@ public class ServerKeyMaterialFactory extends KeyMaterialFactory {
             FilePath tempCredsDir = createSecretsDirectory();
 
             // these file names are defined by convention by docker
-            copyInto(tempCredsDir, "key.pem", key);
-            copyInto(tempCredsDir,"cert.pem", cert);
-            copyInto(tempCredsDir,"ca.pem", ca);
+            copyInto(tempCredsDir, "key.pem", Secret.toString(key));
+            copyInto(tempCredsDir,"cert.pem", Secret.toString(cert));
+            copyInto(tempCredsDir,"ca.pem", Secret.toString(ca));
 
             e.put("DOCKER_TLS_VERIFY", "1");
             e.put("DOCKER_CERT_PATH", tempCredsDir.getRemote());

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
@@ -24,15 +24,15 @@
  -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:s="/io/jenkins/temp/jelly">
   <f:entry title="${%Client Key}" field="clientKey">
-    <f:textarea/>
+    <s:secretTextarea value="${instance.clientKeySecret}"/>
   </f:entry>
   <f:entry title="${%Client Certificate}" field="clientCertificate">
-    <f:textarea/>
+    <s:secretTextarea value="${instance.clientCertificateSecret}"/>
   </f:entry>
   <f:entry title="${%Server CA Certificate}" field="serverCaCertificate">
-    <f:textarea/>
+    <s:secretTextarea value="${instance.serverCaCertificateSecret}"/>
   </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
@@ -24,15 +24,15 @@
  -->
 
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:s="/io/jenkins/temp/jelly">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry title="${%Client Key}" field="clientKey">
-    <s:secretTextarea value="${instance.clientKeySecret}"/>
+    <f:secretTextarea value="${instance.clientKeySecret}"/>
   </f:entry>
   <f:entry title="${%Client Certificate}" field="clientCertificate">
-    <s:secretTextarea value="${instance.clientCertificateSecret}"/>
+    <f:secretTextarea value="${instance.clientCertificateSecret}"/>
   </f:entry>
   <f:entry title="${%Server CA Certificate}" field="serverCaCertificate">
-    <s:secretTextarea value="${instance.serverCaCertificateSecret}"/>
+    <f:secretTextarea value="${instance.serverCaCertificateSecret}"/>
   </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
@@ -26,13 +26,13 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry title="${%Client Key}" field="clientKey">
-    <f:secretTextarea value="${instance.clientKeySecret}"/>
+    <f:secretTextarea/>
   </f:entry>
   <f:entry title="${%Client Certificate}" field="clientCertificate">
-    <f:secretTextarea value="${instance.clientCertificateSecret}"/>
+    <f:secretTextarea/>
   </f:entry>
   <f:entry title="${%Server CA Certificate}" field="serverCaCertificate">
-    <f:secretTextarea value="${instance.serverCaCertificateSecret}"/>
+    <f:secretTextarea/>
   </f:entry>
   <st:include page="id-and-description" class="${descriptor.clazz}"/>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.docker.commons.credentials;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Base64;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -36,7 +37,6 @@ import hudson.model.*;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
 import jenkins.model.Jenkins;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.Charsets;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -111,7 +111,7 @@ public class DockerRegistryEndpointTest {
             DockerRegistryToken token = new DockerRegistryEndpoint("https://index.docker.io/v1/", globalCredentialsId).getToken(item);
             Assert.assertNotNull(token);
             Assert.assertEquals("user", token.getEmail());
-            Assert.assertEquals(Base64.encodeBase64String("user:password".getBytes(Charsets.UTF_8)), token.getToken());
+            Assert.assertEquals(Base64.getEncoder().encodeToString("user:password".getBytes(Charsets.UTF_8)), token.getToken());
         }
     }
 
@@ -137,7 +137,7 @@ public class DockerRegistryEndpointTest {
                     globalCredentialsId).getToken(new FreeStyleBuild(item));
             Assert.assertNotNull(token);
             Assert.assertEquals("user", token.getEmail());
-            Assert.assertEquals(Base64.encodeBase64String("user:password".getBytes(Charsets.UTF_8)), token.getToken());
+            Assert.assertEquals(Base64.getEncoder().encodeToString("user:password".getBytes(Charsets.UTF_8)), token.getToken());
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 /**
  * @author Carlos Sanchez <carlos@apache.org>
@@ -54,6 +55,7 @@ public class DockerRegistryEndpointTest {
     public JenkinsRule j = new JenkinsRule();
 
     @Test
+    @WithoutJenkins
     public void testParse() throws Exception {
         assertRegistry("https://index.docker.io/v1/", "acme/test");
         assertRegistry("https://index.docker.io/v1/", "busybox");
@@ -63,6 +65,7 @@ public class DockerRegistryEndpointTest {
     }
 
     @Test
+    @WithoutJenkins
     public void testParseWithTags() throws Exception {
         assertRegistry("https://index.docker.io/v1/", "acme/test:tag");
         assertRegistry("https://index.docker.io/v1/", "busybox:tag");
@@ -73,6 +76,7 @@ public class DockerRegistryEndpointTest {
 
     @Issue("JENKINS-39181")
     @Test
+    @WithoutJenkins
     public void testParseFullyQualifiedImageName() throws Exception {
         assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("private-repo:5000/test-image"));
         assertEquals("private-repo:5000/test-image", new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName("test-image"));
@@ -80,12 +84,14 @@ public class DockerRegistryEndpointTest {
 
     @Issue("JENKINS-39181")
     @Test(expected = IllegalArgumentException.class)
+    @WithoutJenkins
     public void testParseNullImageName() throws Exception {
         new DockerRegistryEndpoint("http://private-repo:5000/", null).imageName(null);
     }
 
     @Issue("JENKINS-39181")
     @Test(expected = IllegalArgumentException.class)
+    @WithoutJenkins
     public void testParseNullUrlAndImageName() throws Exception {
         new DockerRegistryEndpoint(null, null).imageName(null);
     }

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -33,9 +33,9 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import hudson.model.Computer;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
-import hudson.model.Job;
 import hudson.model.User;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -110,7 +110,7 @@ public class DockerRegistryEndpointTest {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         MockAuthorizationStrategy auth = new MockAuthorizationStrategy()
                 .grant(Jenkins.READ).everywhere().to("alice", "bob")
-                .grant(Job.BUILD).everywhere().to("alice", "bob")
+                .grant(Computer.BUILD).everywhere().to("alice", "bob")
                 // Item.CONFIGURE implies Credentials.USE_ITEM, which is what CredentialsProvider.findCredentialById
                 // uses when determining whether to include item-scope credentials in the search.
                 .grant(Item.CONFIGURE).everywhere().to("alice");
@@ -125,8 +125,8 @@ public class DockerRegistryEndpointTest {
         FreeStyleProject p2 = j.createFreeStyleProject();
 
         Map<String, Authentication> jobsToAuths = new HashMap<>();
-        jobsToAuths.put(p1.getFullName(), User.getById("alice", true).impersonate());
-        jobsToAuths.put(p2.getFullName(), User.getById("bob", true).impersonate());
+        jobsToAuths.put(p1.getName(), User.getById("alice", true).impersonate());
+        jobsToAuths.put(p2.getName(), User.getById("bob", true).impersonate());
         QueueItemAuthenticatorConfiguration.get().getAuthenticators().replace(new MockQueueItemAuthenticator(jobsToAuths));
 
         try (ACLContext as = ACL.as(User.getById("alice", false))) {

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerRegistryEndpointTest.java
@@ -98,31 +98,6 @@ public class DockerRegistryEndpointTest {
 
     @Issue("JENKINS-48437")
     @Test
-    public void testGetTokenForItem() throws IOException {
-        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
-        MockAuthorizationStrategy auth = new MockAuthorizationStrategy()
-                .grant(Jenkins.READ).everywhere().to("alice")
-                .grant(Computer.BUILD).everywhere().to("alice")
-                .grant(Item.CONFIGURE).everywhere().to("alice");
-        j.jenkins.setAuthorizationStrategy(auth);
-
-        String globalCredentialsId = "global-creds";
-        IdCredentials credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL,
-                globalCredentialsId, "test-global-creds", "user", "password");
-        CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
-
-        FreeStyleProject item = j.createFreeStyleProject("testGetToken");
-
-        try (ACLContext as = ACL.as(User.getById("alice", false))) {
-            DockerRegistryToken token = new DockerRegistryEndpoint("https://index.docker.io/v1/", globalCredentialsId).getToken(item);
-            Assert.assertNotNull(token);
-            Assert.assertEquals("user", token.getEmail());
-            Assert.assertEquals(Base64.getEncoder().encodeToString("user:password".getBytes(Charsets.UTF_8)), token.getToken());
-        }
-    }
-
-    @Issue("JENKINS-48437")
-    @Test
     public void testGetTokenForRun() throws IOException {
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         MockAuthorizationStrategy auth = new MockAuthorizationStrategy()
@@ -136,7 +111,7 @@ public class DockerRegistryEndpointTest {
                 globalCredentialsId, "test-global-creds", "user", "password");
         CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), credentials);
 
-        FreeStyleProject item = j.createFreeStyleProject("testGetToken");
+        FreeStyleProject item = j.createFreeStyleProject();
 
         try (ACLContext as = ACL.as(User.getById("alice", false))) {
             DockerRegistryToken token = new DockerRegistryEndpoint("https://index.docker.io/v1/",


### PR DESCRIPTION
Using the backport from https://github.com/jenkinsci/jenkins/pull/3967

This replaces the textarea form input for PKI certificates with a new custom editor for multiline secrets. See the above PR for screenshots.

@jglick @batmat @dwnusbaum @reviewbybees 