### PR TITLE
[JENKINS-57420] - Use f:secretTextarea for client private key

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-7</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>3.43</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <revision>1.15</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.171</jenkins.version>
+    <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -66,6 +66,12 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authentication-tokens</artifactId>
       <version>1.3</version>
+    </dependency>
+    <!-- TODO: remove after upgrading to Jenkins 2.171+ and migrating to f:secretTextarea -->
+    <dependency>
+      <groupId>io.jenkins.temp.jelly</groupId>
+      <artifactId>multiline-secrets-ui</artifactId>
+      <version>1.0</version>
     </dependency>
 
     <!-- for Pipeline-based unit tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.12</version>
+    <version>3.42</version>
     <relativePath />
   </parent>
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>docker-commons</artifactId>
-  <version>1.15-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
 
   <name>Docker Commons Plugin</name>
@@ -31,9 +31,9 @@
   </scm>
 
   <properties>
-    <revision>1.14</revision>
+    <revision>1.15</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.171</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
@@ -50,7 +50,9 @@ public class DockerServerCredentials extends BaseStandardCredentials {
     @CheckForNull 
     private final String serverCaCertificate;
 
-    @Deprecated
+    /**
+     * @deprecated use {@link #DockerServerCredentials(CredentialsScope, String, String, Secret, String, String)}
+     */
     public DockerServerCredentials(CredentialsScope scope, String id, String description,
                                    @CheckForNull String clientKey, @CheckForNull String clientCertificate,
                                    @CheckForNull String serverCaCertificate) {
@@ -60,12 +62,19 @@ public class DockerServerCredentials extends BaseStandardCredentials {
 
     @DataBoundConstructor
     public DockerServerCredentials(CredentialsScope scope, String id, String description,
-                                   @CheckForNull Secret clientKey, @CheckForNull String clientCertificate,
+                                   @CheckForNull Secret clientKeySecret, @CheckForNull String clientCertificate,
                                    @CheckForNull String serverCaCertificate) {
         super(scope, id, description);
-        this.clientKey = clientKey;
+        this.clientKey = clientKeySecret;
         this.clientCertificate = Util.fixEmptyAndTrim(clientCertificate);
         this.serverCaCertificate = Util.fixEmptyAndTrim(serverCaCertificate);
+    }
+
+    /**
+     * @deprecated use {@link #getClientKeySecret()}
+     */
+    public @CheckForNull String getClientKey() {
+        return Secret.toString(clientKey);
     }
 
     /**
@@ -74,7 +83,7 @@ public class DockerServerCredentials extends BaseStandardCredentials {
      * @return null if there's no authentication
      */
     @CheckForNull
-    public Secret getClientKey() {
+    public Secret getClientKeySecret() {
         return clientKey;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
@@ -73,7 +73,8 @@ public class DockerServerCredentials extends BaseStandardCredentials {
     /**
      * @deprecated use {@link #getClientKeySecret()}
      */
-    public @CheckForNull String getClientKey() {
+    @CheckForNull
+    public String getClientKey() {
         return Secret.toString(clientKey);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
@@ -50,12 +50,20 @@ public class DockerServerCredentials extends BaseStandardCredentials {
     @CheckForNull 
     private final String serverCaCertificate;
 
-    @DataBoundConstructor
+    @Deprecated
     public DockerServerCredentials(CredentialsScope scope, String id, String description,
                                    @CheckForNull String clientKey, @CheckForNull String clientCertificate,
                                    @CheckForNull String serverCaCertificate) {
+        this(scope, id, description, Util.fixEmptyAndTrim(clientKey) == null ? null : Secret.fromString(clientKey),
+                clientCertificate, serverCaCertificate);
+    }
+
+    @DataBoundConstructor
+    public DockerServerCredentials(CredentialsScope scope, String id, String description,
+                                   @CheckForNull Secret clientKey, @CheckForNull String clientCertificate,
+                                   @CheckForNull String serverCaCertificate) {
         super(scope, id, description);
-        this.clientKey = Util.fixEmptyAndTrim(clientKey) == null ? null : Secret.fromString(clientKey);
+        this.clientKey = clientKey;
         this.clientCertificate = Util.fixEmptyAndTrim(clientCertificate);
         this.serverCaCertificate = Util.fixEmptyAndTrim(serverCaCertificate);
     }
@@ -66,8 +74,8 @@ public class DockerServerCredentials extends BaseStandardCredentials {
      * @return null if there's no authentication
      */
     @CheckForNull
-    public String getClientKey() {
-        return clientKey == null ? null : clientKey.getPlainText();
+    public Secret getClientKey() {
+        return clientKey;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials.java
@@ -53,6 +53,7 @@ public class DockerServerCredentials extends BaseStandardCredentials {
     /**
      * @deprecated use {@link #DockerServerCredentials(CredentialsScope, String, String, Secret, String, String)}
      */
+    @Deprecated
     public DockerServerCredentials(CredentialsScope scope, String id, String description,
                                    @CheckForNull String clientKey, @CheckForNull String clientCertificate,
                                    @CheckForNull String serverCaCertificate) {
@@ -74,6 +75,7 @@ public class DockerServerCredentials extends BaseStandardCredentials {
      * @deprecated use {@link #getClientKeySecret()}
      */
     @CheckForNull
+    @Deprecated
     public String getClientKey() {
         return Secret.toString(clientKey);
     }

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBinding.java
@@ -10,6 +10,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.util.Secret;
 
 public class DockerServerCredentialsBinding extends AbstractOnDiskBinding<DockerServerCredentials> {
 
@@ -26,7 +27,7 @@ public class DockerServerCredentialsBinding extends AbstractOnDiskBinding<Docker
     @Override
     protected FilePath write(DockerServerCredentials credentials, FilePath dir) throws IOException, InterruptedException {
         FilePath clientKey = dir.child("key.pem");
-        clientKey.write(credentials.getClientKey(), null);
+        clientKey.write(Secret.toString(credentials.getClientKey()), null);
         clientKey.chmod(0600);
 
         FilePath clientCert = dir.child("cert.pem");

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBinding.java
@@ -27,7 +27,7 @@ public class DockerServerCredentialsBinding extends AbstractOnDiskBinding<Docker
     @Override
     protected FilePath write(DockerServerCredentials credentials, FilePath dir) throws IOException, InterruptedException {
         FilePath clientKey = dir.child("key.pem");
-        clientKey.write(Secret.toString(credentials.getClientKey()), null);
+        clientKey.write(Secret.toString(credentials.getClientKeySecret()), null);
         clientKey.chmod(0600);
 
         FilePath clientCert = dir.child("cert.pem");

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.docker.commons.impl;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.util.Secret;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterial;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterialFactory;
@@ -57,7 +58,7 @@ public class ServerKeyMaterialFactory extends KeyMaterialFactory {
 
     public ServerKeyMaterialFactory(@CheckForNull final DockerServerCredentials credentials) {
         if (credentials != null) {
-            key = credentials.getClientKey();
+            key = Secret.toString(credentials.getClientKey());
             cert = credentials.getClientCertificate();
             ca = credentials.getServerCaCertificate();
         } else {

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactory.java
@@ -58,7 +58,7 @@ public class ServerKeyMaterialFactory extends KeyMaterialFactory {
 
     public ServerKeyMaterialFactory(@CheckForNull final DockerServerCredentials credentials) {
         if (credentials != null) {
-            key = Secret.toString(credentials.getClientKey());
+            key = Secret.toString(credentials.getClientKeySecret());
             cert = credentials.getClientCertificate();
             ca = credentials.getServerCaCertificate();
         } else {

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactoryFromDockerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactoryFromDockerCredentials.java
@@ -44,6 +44,6 @@ public class ServerKeyMaterialFactoryFromDockerCredentials extends Authenticatio
     @NonNull
     @Override
     public KeyMaterialFactory convert(@NonNull DockerServerCredentials credential) throws AuthenticationTokenException {
-        return new ServerKeyMaterialFactory(Secret.toString(credential.getClientKey()), credential.getClientCertificate(), credential.getServerCaCertificate());
+        return new ServerKeyMaterialFactory(Secret.toString(credential.getClientKeySecret()), credential.getClientCertificate(), credential.getServerCaCertificate());
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactoryFromDockerCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/ServerKeyMaterialFactoryFromDockerCredentials.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.docker.commons.impl;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.util.Secret;
 import jenkins.authentication.tokens.api.AuthenticationTokenException;
 import jenkins.authentication.tokens.api.AuthenticationTokenSource;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
@@ -43,6 +44,6 @@ public class ServerKeyMaterialFactoryFromDockerCredentials extends Authenticatio
     @NonNull
     @Override
     public KeyMaterialFactory convert(@NonNull DockerServerCredentials credential) throws AuthenticationTokenException {
-        return new ServerKeyMaterialFactory(credential.getClientKey(), credential.getClientCertificate(), credential.getServerCaCertificate());
+        return new ServerKeyMaterialFactory(Secret.toString(credential.getClientKey()), credential.getClientCertificate(), credential.getServerCaCertificate());
     }
 }

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
@@ -26,7 +26,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry title="${%Client Key}" field="clientKey">
-    <f:textarea/>
+    <f:secretTextarea/>
   </f:entry>
   <f:entry title="${%Client Certificate}" field="clientCertificate">
     <f:textarea/>

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
@@ -26,7 +26,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry title="${%Client Key}" field="clientKeySecret">
-    <f:secretTextarea/>
+    <s:secretTextarea xmlns:s="/io/jenkins/temp/jelly"/>
   </f:entry>
   <f:entry title="${%Client Certificate}" field="clientCertificate">
     <f:textarea/>

--- a/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentials/credentials.jelly
@@ -25,7 +25,7 @@
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
-  <f:entry title="${%Client Key}" field="clientKey">
+  <f:entry title="${%Client Key}" field="clientKeySecret">
     <f:secretTextarea/>
   </f:entry>
   <f:entry title="${%Client Certificate}" field="clientCertificate">

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/ConfigTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/ConfigTest.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.docker.commons;
 
+import hudson.util.Secret;
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
 import org.jenkinsci.plugins.docker.commons.util.SampleDockerBuilder;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
@@ -48,7 +49,7 @@ public class ConfigTest {
 
     @Test public void configRoundTrip() throws Exception {
         CredentialsStore store = CredentialsProvider.lookupStores(r.jenkins).iterator().next();
-        IdCredentials serverCredentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "serverCreds", null, "clientKey", "clientCertificate", "serverCaCertificate");
+        IdCredentials serverCredentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "serverCreds", null, Secret.fromString("clientKey"), "clientCertificate", "serverCaCertificate");
         store.addCredentials(Domain.global(), serverCredentials);
         IdCredentials registryCredentials = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "registryCreds", null, "me", "pass");
         store.addCredentials(Domain.global(), registryCredentials);

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsBindingTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 
+import hudson.util.Secret;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.jenkinsci.plugins.credentialsbinding.impl.BindingStep;
@@ -73,7 +74,7 @@ public class DockerServerCredentialsBindingTest {
                 Domain domain = new Domain("docker", "A domain for docker credentials",
                         Collections.<DomainSpecification> singletonList(new DockerServerDomainSpecification()));
                 DockerServerCredentials c = new DockerServerCredentials(CredentialsScope.GLOBAL,
-                        "docker-client-cert", "desc", "clientKey", "clientCertificate", "serverCaCertificate");
+                        "docker-client-cert", "desc", Secret.fromString("clientKey"), "clientCertificate", "serverCaCertificate");
                 store.addDomain(domain, c);
                 BindingStep s = new StepConfigTester(story.j)
                         .configRoundTrip(new BindingStep(Collections.<MultiBinding> singletonList(
@@ -90,7 +91,7 @@ public class DockerServerCredentialsBindingTest {
             @Override
             public void evaluate() throws Throwable {
                 DockerServerCredentials c = new DockerServerCredentials(CredentialsScope.GLOBAL,
-                        "docker-client-cert", "desc", "clientKey", "clientCertificate", "serverCaCertificate");
+                        "docker-client-cert", "desc", Secret.fromString("clientKey"), "clientCertificate", "serverCaCertificate");
                 CredentialsProvider.lookupStores(story.j.jenkins).iterator().next().addCredentials(Domain.global(), c);
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 String pipelineScript = IOUtils.toString(getTestResourceInputStream("basics-Jenkinsfile"));

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
@@ -60,7 +60,7 @@ public class DockerServerCredentialsTest {
         assertThat(store, instanceOf(SystemCredentialsProvider.StoreImpl.class));
         Domain domain = new Domain("docker", "A domain for docker credentials",
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
-        DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", "", "", "");
+        DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", Secret.fromString(""), "", "");
         store.addDomain(domain, credentials);
 
         j.submit(j.createWebClient().goTo("credentials/store/system/domain/" + domain.getName() + "/credential/"+credentials.getId()+"/update")
@@ -76,7 +76,7 @@ public class DockerServerCredentialsTest {
         assertThat(store, instanceOf(SystemCredentialsProvider.StoreImpl.class));
         Domain domain = new Domain("docker", "A domain for docker credentials",
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
-        DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", "a", "b", "c");
+        DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", Secret.fromString("a"), "b", "c");
         store.addDomain(domain, credentials);
 
         j.submit(j.createWebClient().goTo("credentials/store/system/domain/" + domain.getName() + "/credential/"+credentials.getId()+"/update")
@@ -99,7 +99,7 @@ public class DockerServerCredentialsTest {
             button.click();
         }
 
-        form.getTextAreaByName("_.clientKey").setText("new key");
+        form.getTextAreaByName("_.clientKeySecret").setText("new key");
         form.getTextAreaByName("_.clientCertificate").setText("new cert");
         form.getTextAreaByName("_.serverCaCertificate").setText("new ca cert");
         j.submit(form);

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpointTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerEndpointTest.java
@@ -34,6 +34,7 @@ import hudson.Functions;
 import hudson.model.FreeStyleProject;
 import hudson.remoting.VirtualChannel;
 import hudson.slaves.DumbSlave;
+import hudson.util.Secret;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -63,7 +64,7 @@ public class DockerServerEndpointTest {
         assertThat(store, instanceOf(SystemCredentialsProvider.StoreImpl.class));
         Domain domain = new Domain("docker", "A domain for docker credentials",
                 Collections.<DomainSpecification>singletonList(new DockerServerDomainSpecification()));
-        DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", "a", "b", "c");
+        DockerServerCredentials credentials = new DockerServerCredentials(CredentialsScope.GLOBAL, "foo", "desc", Secret.fromString("a"), "b", "c");
         store.addDomain(domain, credentials);
         DockerServerEndpoint endpoint = new DockerServerEndpoint("tcp://localhost:2736", credentials.getId());
         FilePath dotDocker = DockerServerEndpoint.dotDocker(channel);


### PR DESCRIPTION
This updates the form UI for client keys to use the newly introduced
f:secretTextarea Jelly tag from Jenkins 2.171. Now the client key can
be more securely entered and updated.

Recreated based on #75.

@jglick @jeffret-b @Wadeck @dwnusbaum 