### PR TITLE
[JENKINS-59501] - Add synchronization to `addRunFacet()` to prevent `ConcurrentModificationException`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
@@ -223,6 +223,7 @@ public class DockerFingerprints {
     public static void addRunFacet(@Nonnull ContainerRecord record, @Nonnull Run<?,?> run) throws IOException {
         String imageId = record.getImageId();
         Fingerprint f = forImage(run, imageId);
+        synchronized (f) {
         Collection<FingerprintFacet> facets = f.getFacets();
         DockerRunFingerprintFacet runFacet = null;
         for (FingerprintFacet facet : facets) {
@@ -243,6 +244,7 @@ public class DockerFingerprints {
             bc.commit();
         } finally {
             bc.abort();
+        }
         }
     }
 


### PR DESCRIPTION
This will prevent rare ConcurrentModificationExceptions when multiple
calls to image.inside() step is done.

This is more a carbon copy of PR-69, but for one of the neighbor methods with the same concurrency problem.

Note that I've not indented the synchronization block in order to not mess with the git history (same as in the other PR).