### PR TITLE
Add ability to disable fingerprint recording

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
@@ -23,6 +23,7 @@
  */
 package org.jenkinsci.plugins.docker.commons.fingerprint;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
 import hudson.model.Fingerprint;
 import hudson.model.Run;
@@ -47,6 +48,9 @@ import org.apache.commons.lang.StringUtils;
 public class DockerFingerprints {
     
     private static final Logger LOGGER = Logger.getLogger(DockerFingerprints.class.getName());
+
+    @SuppressFBWarnings(value="MS_SHOULD_BE_FINAL", justification="mutable for scripts")
+    public static boolean DISABLE = Boolean.getBoolean(DockerFingerprints.class.getName() + ".DISABLE");
     
     private DockerFingerprints() {} // no instantiation
  
@@ -221,6 +225,9 @@ public class DockerFingerprints {
      * Adds a new {@link ContainerRecord} for the specified image, creating necessary intermediate objects as it goes.
      */
     public static void addRunFacet(@Nonnull ContainerRecord record, @Nonnull Run<?,?> run) throws IOException {
+        if (DISABLE) {
+            return;
+        }
         String imageId = record.getImageId();
         Fingerprint f = forImage(run, imageId);
         synchronized (f) {
@@ -256,6 +263,9 @@ public class DockerFingerprints {
      * @param run the build in which the image building occurred
      */
     public static void addFromFacet(@CheckForNull String ancestorImageId, @Nonnull String descendantImageId, @Nonnull Run<?,?> run) throws IOException {
+        if (DISABLE) {
+            return;
+        }
         long timestamp = System.currentTimeMillis();
         if (ancestorImageId != null) {
             Fingerprint f = forImage(run, ancestorImageId);


### PR DESCRIPTION
It seems like the fingerprinting functionality has been broken for a while (e.g. [see this comment by Jesse Glick](https://issues.jenkins-ci.org/browse/JENKINS-46498?focusedCommentId=338220#comment-338220)) and causes a lot of problems, especially in large Jenkins instances. This change introduces a property which disables the functionality all together.

Some background, in our case, where we run 10k+ builds a day using the same docker image, the fingerprint file for that image grows very large 50+ MB and around 100k container entries. The large size causes Jenkins to spend more and more time saving the file (serialization, file IO, etc). In the end, when it gets large enough, the builds are aborted without anything being written in the logs (separate issue, but it seems like if more than five minutes is spent in the step start / fingerprint recording phase, then the build is terminated without anything written in the log). At that size it takes around 3-4 seconds to save the file, and if 100 builds are starting containers at the same time, then some of them will spend more than five minutes waiting.