### PR TITLE
docker login - get password from stdin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/RegistryKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/RegistryKeyMaterialFactory.java
@@ -24,6 +24,7 @@
 
 package org.jenkinsci.plugins.docker.commons.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -95,10 +96,9 @@ public class RegistryKeyMaterialFactory extends KeyMaterialFactory {
         }
 
         try {
-            // TODO on Docker 17.07+ use --password-stdin
             EnvVars envWithConfig = new EnvVars(env);
             envWithConfig.put("DOCKER_CONFIG", dockerConfig.getRemote());
-            if (launcher.launch().cmds(new ArgumentListBuilder(dockerExecutable, "login", "-u", username, "-p").add(password, true).add(endpoint)).envs(envWithConfig).stdout(listener).join() != 0) {
+            if (launcher.launch().cmds(new ArgumentListBuilder(dockerExecutable, "login", "-u", username, "--password-stdin").add(endpoint)).envs(envWithConfig).stdin(new ByteArrayInputStream(password.getBytes("UTF-8"))).stdout(listener).join() != 0) {
                 throw new AbortException("docker login failed");
             }
         } catch (IOException | InterruptedException x) {


### PR DESCRIPTION
This patch causes the `docker login` process to read the password from stdin rather than as an argument. Using an argument for the password causes issues with complex passwords (such as the JSON documents needed GCR) or passwords with special shell characters ($ especially.)

The `--password-stdin` flag was introduced in Docker version 17.07.0 so it's been around for a decent amount of time by now. The oldest supported version that doesn't have this flag (enterprise 17.06) is EOL on 2020-04-16, so perhaps this change could be merged in after that date.

This change will solve these open issues:

https://issues.jenkins-ci.org/browse/JENKINS-52761
https://issues.jenkins-ci.org/browse/JENKINS-53770