### PR TITLE
Install docker from stable channel

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstaller.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstaller.java
@@ -150,7 +150,7 @@ public class DockerToolInstaller extends ToolInstaller {
     static URL getDockerImageUrl(String os, String version) throws MalformedURLException {
         final int i = os.indexOf("/");
         if (parseVersion(version).isNewerThan(parseVersion("17.05.0-ce"))) {
-            return new URL("https://download.docker.com/" + os.substring(0, i) + "/static/edge/"+ os.substring(i + 1) + "/docker-" + version);
+            return new URL("https://download.docker.com/" + os.substring(0, i) + "/static/stable/"+ os.substring(i + 1) + "/docker-" + version);
         }
 
         return new URL("https://get.docker.com/builds/" + FindArch.asGetDockerArchName(os) + os.substring(i +1) + "/docker-" + version);

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstallerTest.java
@@ -65,9 +65,12 @@ public class DockerToolInstallerTest {
         assertEquals(new URL("https://get.docker.com/builds/Linux/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "latest"));
         assertEquals(new URL("https://get.docker.com/builds/Windows/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("win/x86_64","latest"));
         assertEquals(new URL("https://get.docker.com/builds/Darwin/x86_64/docker-latest"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","latest"));
-        assertEquals(new URL("https://download.docker.com/linux/static/edge/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "17.09.0-ce"));
-        assertEquals(new URL("https://download.docker.com/win/static/edge/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("win/x86_64","17.09.0-ce"));
-        assertEquals(new URL("https://download.docker.com/mac/static/edge/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/linux/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/win/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("win/x86_64","17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/mac/static/stable/x86_64/docker-17.09.0-ce"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","17.09.0-ce"));
+        assertEquals(new URL("https://download.docker.com/linux/static/stable/x86_64/docker-20.10.6"), DockerToolInstaller.getDockerImageUrl("linux/x86_64", "20.10.6"));
+        assertEquals(new URL("https://download.docker.com/win/static/stable/x86_64/docker-20.10.6"), DockerToolInstaller.getDockerImageUrl("win/x86_64","20.10.6"));
+        assertEquals(new URL("https://download.docker.com/mac/static/stable/x86_64/docker-20.10.6"), DockerToolInstaller.getDockerImageUrl("mac/x86_64","20.10.6"));
     }
 
     @Issue({"JENKINS-36082", "JENKINS-32790", "JENKINS-48674"})
@@ -80,7 +83,7 @@ public class DockerToolInstallerTest {
         } catch (IOException x) {
             Assume.assumeNoException("Cannot contact download sites, perhaps test machine is not online", x);
         }
-        String[] testedVersions = {"17.09.1-ce", "1.12.6", "1.10.0", "latest"};
+        String[] testedVersions = {"20.10.6", "17.09.1-ce", "1.12.6", "1.10.0", "latest"};
         DockerTool[] installations = new DockerTool[testedVersions.length];
         for (int i = 0; i < testedVersions.length; i++) {
             String v = testedVersions[i];


### PR DESCRIPTION
Edge channel has 19.03.9 as latest version available
https://download.docker.com/linux/static/edge/x86_64/
Imho it has to be changed  to stable channel
https://download.docker.com/linux/static/stable/x86_64/

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira (none found)
- [x] Link to relevant pull requests, esp. upstream and downstream changes (none found)
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

