### PR TITLE
Deleting `CredentialsBindingHandler.toBindings`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsHandler.java
@@ -25,7 +25,6 @@ package org.jenkinsci.plugins.docker.commons.credentials;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import hudson.Extension;
-import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.jenkinsci.plugins.pipeline.modeldefinition.model.CredentialsBindingHandler;
 
 import javax.annotation.Nonnull;
@@ -36,12 +35,6 @@ import java.util.Map;
 
 @Extension(optional = true)
 public class DockerServerCredentialsHandler extends CredentialsBindingHandler<DockerServerCredentials> {
-
-    @Nonnull
-    @Override
-    public List<MultiBinding<DockerServerCredentials>> toBindings(String varName, String credentialsId) {
-        return Collections.singletonList(new DockerServerCredentialsBinding(varName, credentialsId));
-    }
 
     @Nonnull
     @Override


### PR DESCRIPTION
See https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/418: unused as of `pipeline-model-definition` 1.1.4 (older than the dep here).