### PR TITLE
Update DockerToolInstaller.java to use stable instead of edge releases

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstaller.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/tools/DockerToolInstaller.java
@@ -150,7 +150,7 @@ public class DockerToolInstaller extends ToolInstaller {
     static URL getDockerImageUrl(String os, String version) throws MalformedURLException {
         final int i = os.indexOf("/");
         if (parseVersion(version).isNewerThan(parseVersion("17.05.0-ce"))) {
-            return new URL("https://download.docker.com/" + os.substring(0, i) + "/static/edge/"+ os.substring(i + 1) + "/docker-" + version);
+            return new URL("https://download.docker.com/" + os.substring(0, i) + "/static/stable/"+ os.substring(i + 1) + "/docker-" + version);
         }
 
         return new URL("https://get.docker.com/builds/" + FindArch.asGetDockerArchName(os) + os.substring(i +1) + "/docker-" + version);


### PR DESCRIPTION
Updated the url for docker installs from download.docker.com to use the stable releases instead of edge.
