### PR TITLE
Use "agent" in the javadoc rather than "slave"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/docker/commons/tools/DockerTool.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/tools/DockerTool.java
@@ -66,7 +66,7 @@ public class DockerTool extends ToolInstallation implements EnvironmentSpecific<
      * Gets the executable name to use for a given launcher.
      * Suitable for the first item in {@link ArgumentListBuilder}.
      * @param name the name of the selected tool, or null for the default
-     * @param node optionally, a node (such as a slave) on which we are running Docker
+     * @param node optionally, a node (such as an agent) on which we are running Docker
      * @param listener a listener, required in case {@code node} is not null
      * @param env optionally, environment variables to use when expanding the home directory
      * @return {@code docker} or an absolute path


### PR DESCRIPTION
## Use agent in javadoc rather than slave

Update javadoc comment to use `agent` rather than `slave`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
