### PR TITLE
Adapt DockerServerCredentialsTest for 2.413+ credentials page

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
@@ -35,6 +35,7 @@ import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
 import hudson.security.ACL;
 import hudson.util.Secret;
+import hudson.util.VersionNumber;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -98,7 +99,13 @@ public class DockerServerCredentialsTest {
             button.click();
         }
 
-        form.getTextAreaByName("_.clientKeySecret").setText("new key");
+        if (j.jenkins.getVersion().isOlderThan(new VersionNumber("2.413"))) {
+            /* Jenkins 2.412 and earlier use a text area for the client key */
+            form.getTextAreaByName("_.clientKeySecret").setText("new key");
+        } else {
+            /* Jenkins 2.413 and newer use an input field for the client key */
+            form.getInputByName("_.clientKeySecret").setValue("new key");
+        }
         form.getTextAreaByName("_.clientCertificate").setText("new cert");
         form.getTextAreaByName("_.serverCaCertificate").setText("new ca cert");
         j.submit(form);

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
@@ -35,7 +35,6 @@ import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlForm;
 import hudson.security.ACL;
 import hudson.util.Secret;
-import hudson.util.VersionNumber;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -95,17 +94,9 @@ public class DockerServerCredentialsTest {
         store.addDomain(domain, credentials);
 
         HtmlForm form = getUpdateForm(domain, credentials);
-        for (HtmlElement button : form.getElementsByAttribute("input", "class", "secret-update-btn")) {
-            button.click();
-        }
+        ((HtmlElement) form.querySelector(".secret-update-btn")).click();
 
-        if (j.jenkins.getVersion().isOlderThan(new VersionNumber("2.413"))) {
-            /* Jenkins 2.412 and earlier use a text area for the client key */
-            form.getTextAreaByName("_.clientKeySecret").setText("new key");
-        } else {
-            /* Jenkins 2.413 and newer use an input field for the client key */
-            form.getInputByName("_.clientKeySecret").setValue("new key");
-        }
+        form.getTextAreaByName("_.clientKeySecret").setText("new key");
         form.getTextAreaByName("_.clientCertificate").setText("new cert");
         form.getTextAreaByName("_.serverCaCertificate").setText("new ca cert");
         j.submit(form);


### PR DESCRIPTION
## Adapt DockerServerCredentialsTest for 2.413 UI improvement

Jenkins 2.412 and earlier use a text area for the client key data entry on the credentials page.

Jenkins 2.413 and newer use an input field for the client key data entry on the credentials page.

Jenkins 2.413 looks much nicer with a button that is consistent with the other buttons used in the Jenkins pages.

https://github.com/jenkinsci/jenkins/pull/8179 is the Jenkins core pull request that implemented the change in Jenkins 2.413.  Other plugins that use HTMLUnit to enter a value for the secret text may need a similar change.  Special thanks to @mawinter69 for implementing that improvement in Jenkins 2.413.

### Testing done

Compared the HTML pages generated by 2.412 and 2.413 and confirmed that 2.412 uses a textarea and 2.413 uses an input field.  The 2.413 layout looks much nicer.

Automated test passes on both Jenkins 2.412 and 2.413 with this change.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
