### PR TITLE
Trying to deflake `credentials`-related tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,12 @@
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.3.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerCredentialsTest.java
@@ -44,9 +44,11 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.UUID;
+import static org.awaitility.Awaitility.await;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.jvnet.hudson.test.QueryUtils.waitUntilElementIsPresent;
 
 /**
@@ -127,8 +129,10 @@ public class DockerServerCredentialsTest {
     private HtmlForm getUpdateForm(Domain domain, DockerServerCredentials credentials) throws IOException, SAXException {
         HtmlPage page = j.createWebClient().goTo("credentials/store/system/domain/" + domain.getName() + "/credential/" + credentials.getId());
         HtmlElement button = page.getFirstByXPath("//button[normalize-space(.)='Update credential']");
-        page = button.click();
-        return (HtmlForm) waitUntilElementIsPresent(page, "form[name=updateCredentials]");
+        HtmlPage page2 = button.click();
+        HtmlForm form = (HtmlForm) waitUntilElementIsPresent(page2, "form[name=updateCredentials]");
+        await().logging().until(() -> page2.getWebClient().waitForBackgroundJavaScript(1), is(0));
+        return form;
     }
 
     private IdCredentials findFirstWithId(String credentialsId) {

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerDomainSpecificationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/DockerServerDomainSpecificationTest.java
@@ -38,9 +38,11 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import static org.awaitility.Awaitility.await;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.jvnet.hudson.test.QueryUtils.waitUntilElementIsPresent;
 
 /**
@@ -65,8 +67,9 @@ public class DockerServerDomainSpecificationTest {
 
         HtmlPage page = j.createWebClient().goTo("credentials/store/system/domain/" + domain.getName());
         HtmlElement button = page.getFirstByXPath("//button[normalize-space(.)='Update domain']");
-        page = button.click();
+        HtmlPage page2 = button.click();
         HtmlForm form = (HtmlForm) waitUntilElementIsPresent(page, "form[id=credentials-dialog-form]");
+        await().logging().until(() -> page2.getWebClient().waitForBackgroundJavaScript(1), is(0));
         j.submit(form);
 
         j.assertEqualDataBoundBeans(domain, byName(store.getDomains(),domain.getName()));


### PR DESCRIPTION
Amending #183 in line with https://github.com/jenkinsci/oidc-provider-plugin/pull/164 to allow https://github.com/jenkinsci/bom/pull/6535 to be reverted. Trickier to reproduce the flake and thus verify that this PR improves anything; I saw a failure in `DockerServerDomainSpecificationTest` just once.