### PR TITLE
Remove commons-lang2 usages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.528</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
@@ -26,7 +26,6 @@ package org.jenkinsci.plugins.docker.commons.credentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.util.FormValidation;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.Arrays;
 import java.util.regex.Pattern;
@@ -59,7 +58,7 @@ public class ImageNameValidator {
      */
     public static @NonNull String[] splitUserAndRepo(@NonNull String userAndRepo) {
         String[] args = new String[4];
-        if (StringUtils.isEmpty(userAndRepo)) {
+        if (userAndRepo.isEmpty()) {
             return args;
         }
         int slashIdx = userAndRepo.lastIndexOf('/');
@@ -108,8 +107,10 @@ public class ImageNameValidator {
             return FormValidation.ok();
         }
         final String[] args = splitUserAndRepo(userAndRepo);
-        if (StringUtils.isBlank(args[0]) && StringUtils.isBlank(args[1]) && StringUtils.isBlank(args[2])
-                && StringUtils.isBlank(args[3])) {
+        if ((args[0] == null || args[0].isBlank())
+                && (args[1] == null || args[1].isBlank())
+                && (args[2] == null || args[2].isBlank())
+                && (args[3] == null || args[3].isBlank())) {
             return FormValidation.error("Bad imageName format: %s", userAndRepo);
         }
         final FormValidation name = validateName(args[1]);
@@ -181,7 +182,7 @@ public class ImageNameValidator {
         if (SKIP) {
             return FormValidation.ok();
         }
-        if (StringUtils.isEmpty(digest)) {
+        if (digest == null || digest.isEmpty()) {
             return FormValidation.ok();
         }
         if (digest.startsWith("@sha256")) { 
@@ -232,7 +233,7 @@ public class ImageNameValidator {
         if (SKIP) {
             return FormValidation.ok();
         }
-        if (StringUtils.isEmpty(tag)) {
+        if (tag == null || tag.isEmpty()) {
             return FormValidation.ok();
         }
         if (tag.length() > 128) {
@@ -280,7 +281,7 @@ public class ImageNameValidator {
         if (SKIP) {
             return FormValidation.ok();
         }
-        if (StringUtils.isEmpty(name)) {
+        if (name == null || name.isEmpty()) {
             return FormValidation.error("Missing name.");
         }
         if (VALID_NAME_COMPONENT.matcher(name).matches()) {

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
@@ -56,9 +56,9 @@ public class ImageNameValidator {
      * @return an array where position 0 is the namespace, 1 is the name and 2 is the tag and 3 is the digest.
      *         Any position could be <code>null</code>
      */
-    public static @NonNull String[] splitUserAndRepo(@NonNull String userAndRepo) {
+    public static @NonNull String[] splitUserAndRepo(@CheckForNull String userAndRepo) {
         String[] args = new String[4];
-        if (userAndRepo.isEmpty()) {
+        if (userAndRepo ==null || userAndRepo.isEmpty()) {
             return args;
         }
         int slashIdx = userAndRepo.lastIndexOf('/');

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
@@ -56,9 +56,9 @@ public class ImageNameValidator {
      * @return an array where position 0 is the namespace, 1 is the name and 2 is the tag and 3 is the digest.
      *         Any position could be <code>null</code>
      */
-    public static @NonNull String[] splitUserAndRepo(@CheckForNull String userAndRepo) {
+    public static @NonNull String[] splitUserAndRepo(@NonNull String userAndRepo) {
         String[] args = new String[4];
-        if (userAndRepo == null || userAndRepo.isEmpty()) {
+        if (userAndRepo.isEmpty()) {
             return args;
         }
         int slashIdx = userAndRepo.lastIndexOf('/');

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidator.java
@@ -58,7 +58,7 @@ public class ImageNameValidator {
      */
     public static @NonNull String[] splitUserAndRepo(@CheckForNull String userAndRepo) {
         String[] args = new String[4];
-        if (userAndRepo ==null || userAndRepo.isEmpty()) {
+        if (userAndRepo == null || userAndRepo.isEmpty()) {
             return args;
         }
         int slashIdx = userAndRepo.lastIndexOf('/');

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/fingerprint/DockerFingerprints.java
@@ -38,7 +38,6 @@ import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.FingerprintFacet;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Entry point into fingerprint related functionalities in Docker.
@@ -139,7 +138,7 @@ public class DockerFingerprints {
     
     private static @NonNull Fingerprint forDockerInstance(@CheckForNull Run<?,?> run, 
             @NonNull String id, @CheckForNull String name, @NonNull String prefix) throws IOException {
-        final String imageName = prefix + (StringUtils.isNotBlank(name) ? name : id);
+        final String imageName = prefix + (name !=null && !name.isBlank() ? name : id);
         return Jenkins.get().getFingerprintMap().getOrCreate(run, imageName, getFingerprintHash(id));
     }
 

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/RegistryKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/RegistryKeyMaterialFactory.java
@@ -82,7 +82,7 @@ public class RegistryKeyMaterialFactory extends KeyMaterialFactory {
         FilePath configJsonPath = FilePath.getHomeDirectory(this.launcher.getChannel()).child(".docker").child(DOCKER_CONFIG_FILENAME);
         if (configJsonPath.exists()) {
             String configJson = configJsonPath.readToString();
-            if (configJson != null && !configJson.isBlank()) {
+            if (!configJson.isBlank()) {
                 launcher.getListener().getLogger().println("Using the existing docker config file.");
 
                 JSONObject json = JSONObject.fromObject(configJson);

--- a/src/main/java/org/jenkinsci/plugins/docker/commons/impl/RegistryKeyMaterialFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/docker/commons/impl/RegistryKeyMaterialFactory.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterial;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterialFactory;
 import org.kohsuke.accmod.Restricted;
@@ -83,7 +82,7 @@ public class RegistryKeyMaterialFactory extends KeyMaterialFactory {
         FilePath configJsonPath = FilePath.getHomeDirectory(this.launcher.getChannel()).child(".docker").child(DOCKER_CONFIG_FILENAME);
         if (configJsonPath.exists()) {
             String configJson = configJsonPath.readToString();
-            if (StringUtils.isNotBlank(configJson)) {
+            if (configJson != null && !configJson.isBlank()) {
                 launcher.getListener().getLogger().println("Using the existing docker config file.");
 
                 JSONObject json = JSONObject.fromObject(configJson);

--- a/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/docker/commons/credentials/ImageNameValidatorTest.java
@@ -50,7 +50,6 @@ public class ImageNameValidatorTest {
                 {"name\necho hello:tag",                                                                                             FormValidation.Kind.ERROR},
                 {"name:tag$BUILD_NUMBER",                                                                                            FormValidation.Kind.ERROR},
                 {"name$BUILD_NUMBER:tag",                                                                                            FormValidation.Kind.ERROR},
-                {null,                                                                                                               FormValidation.Kind.ERROR},
                 {"",                                                                                                                 FormValidation.Kind.ERROR},
                 {":",                                                                                                                FormValidation.Kind.ERROR},
                 {"  ",                                                                                                               FormValidation.Kind.ERROR},


### PR DESCRIPTION
Jenkins core will be dropping commons-lang2, and we would need to remove the usages in all plugins.
Instead of migrating to commons-lang3 - https://github.com/jenkinsci/docker-commons-plugin/pull/174, lets use the jdk apis directly as the usages are small and simple.

### Testing done

* maven compilation works.
* code analysis manual and with AI as simple changes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

